### PR TITLE
TypeError: Cannot read properties of undefined (reading 'ref') in hydrationUtils

### DIFF
--- a/src/utils/hydrationUtils.ts
+++ b/src/utils/hydrationUtils.ts
@@ -12,7 +12,7 @@ type FieldWithReferenceModel = {
 };
 
 export const getReferenceModelNameFromSchema = (schema: SchemaType): string => {
-    if (schema.options.ref) {
+    if (schema?.options?.ref) {
         return schema.options.ref as string;
     }
     if (Array.isArray(schema?.options?.type) && schema.options.type.length) {


### PR DESCRIPTION
I had an issue that come from `getReferenceModelNameFromSchema` function,  Fixed it by adding an optional chaining operator `?.` details in this video:

https://github.com/arqo123/speedgoose/assets/64564291/eab444b3-6034-4bff-b812-2a36dcb2058b

version 2.0.12