### PR TITLE
fix(cachePopulate): correctly populate an array of references with broken relations

### DIFF
--- a/src/utils/populationUtils.ts
+++ b/src/utils/populationUtils.ts
@@ -103,7 +103,7 @@ export const stitchAndRelateDocuments = async <T extends Document>(
     for (const doc of documents) {
         const ids = mpath.get(path, doc);
         const getCacheValue = (id: any) => docsFromCache.get(getDocumentCacheKey(populatedModel.modelName, id.toString(), select));
-        const populatedValue = Array.isArray(ids) ? ids.map(getCacheValue) : getCacheValue(ids);
+        const populatedValue = Array.isArray(ids) ? ids.map(getCacheValue).filter(Boolean) : getCacheValue(ids);
 
         const hydratedValue = hydratePopulatedData(populatedValue, populatedModel, isLean);
         mpath.set(path, hydratedValue, doc);


### PR DESCRIPTION
Hi, this PR fixes the issue with **cachePopulate** when we try to populate an array of references with broken relations. After the fix, the behaviour of the cached query and the DB query result will be the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where populating array fields with references to non-existent documents now properly ignores missing references instead of including undefined/null values in the populated data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->