### PR TITLE
fix(getValueFromCache): should return null in case the value was not found in the cache

### DIFF
--- a/src/cachingStrategies/inMemoryStrategy.ts
+++ b/src/cachingStrategies/inMemoryStrategy.ts
@@ -21,8 +21,9 @@ export class InMemoryStrategy extends CommonCacheStrategyAbstract {
 
     public async getValueFromCache(namespace: string, key: string): Promise<CachedResult> {
         const keyWithNamespace = `${namespace}:${key}`;
+        const result = await this.resultsCacheClient.get(keyWithNamespace)
 
-        return this.resultsCacheClient.get(keyWithNamespace);
+        return result || null;
     }
 
     public async isValueCached(namespace: string, key: string): Promise<boolean> {

--- a/test/cachingStrategies/inMemoryStrategy.test.ts
+++ b/test/cachingStrategies/inMemoryStrategy.test.ts
@@ -12,6 +12,15 @@ describe('InMemoryStrategy.isHydrationEnabled', () => {
     });
 });
 
+describe('InMemoryStrategy.getValueFromCache', () => {
+    test(`should return null in case the value was not found in the cache`, async () => {
+        const strategy = getCacheStrategyInstance();
+        const result = await strategy.getValueFromCache(CacheNamespaces.RESULTS_NAMESPACE, 'randomKey');
+
+        expect(result).toBeNull();
+    });
+});
+
 describe('InMemoryStrategy.refreshTTLForCachedResult', () => {
     test(`should call re-set entry with passed data and`, async () => {
         const strategy = getCacheStrategyInstance();

--- a/test/utils/cacheClientUtils.test.ts
+++ b/test/utils/cacheClientUtils.test.ts
@@ -153,16 +153,16 @@ describe(`clearCacheForKey`, () => {
             value: 'rabbit',
         };
 
-        const strategy = await getCacheStrategyInstance();
+        const strategy = getCacheStrategyInstance();
         //setting value to clear
         await strategy.addValueToCache(CacheNamespaces.RESULTS_NAMESPACE, testCase.key, testCase.value);
         //checking if the value is set
         expect(await strategy.getValueFromCache(CacheNamespaces.RESULTS_NAMESPACE, testCase.key)).toEqual(testCase.value);
-        //ok rabbit is still there. Lets do some magic
+        //ok rabbit is still there. Let's do some magic
         await clearCacheForKey(testCase.key);
         const cachedValue = await strategy.getValueFromCache(CacheNamespaces.RESULTS_NAMESPACE, testCase.key);
         // expect(cachedValue).not.toEqual(testCase.value)
-        expect(cachedValue).toBeUndefined();
+        expect(cachedValue).toBeNull();
     });
 });
 
@@ -219,7 +219,7 @@ describe(`clearCachedResultsForModel`, () => {
 
         await cacheClientUtils.clearCachedResultsForModel(testCase.modelName, testCase.multitenantValue);
         expect(await strategy.getValuesFromCachedSet(modelCacheKey)).toEqual([]);
-        expect(await strategy.getValueFromCache(CacheNamespaces.RESULTS_NAMESPACE, testCase.cacheQueryKey)).toBeUndefined();
+        expect(await strategy.getValueFromCache(CacheNamespaces.RESULTS_NAMESPACE, testCase.cacheQueryKey)).toBeNull();
     });
 });
 


### PR DESCRIPTION
Hi, I found a small inconsistency in the **getValueFromCache** method.  The **redisStrategy** returns _null_ while the **inMemoryStrategy** returns _undefined_. This PR will fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated caching behavior to properly handle cache misses.

* **Tests**
  * Added test coverage for cache miss scenarios.
  * Updated existing test suite to reflect caching behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->