### PR TITLE
feat: add support for custom loggers

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -56,6 +56,8 @@ export type SpeedGooseConfig = {
         debugModels?: string[];
         /** An array of operations to debug, if not set then debugger will log all operations */
         debugOperations?: SpeedGooseDebuggerOperations[];
+        /** Custom logger function - when provided, logs will be sent here instead of the debug library */
+        customLogger?: (namespace: string, message: string, ...data: unknown[]) => void;
     };
     /** Cache strategy for shared results, by default it is SharedCacheStrategies.REDIS */
     sharedCacheStrategy?: SharedCacheStrategies;

--- a/src/utils/debugUtils.ts
+++ b/src/utils/debugUtils.ts
@@ -29,8 +29,18 @@ export const emptyDebugCallback = (): object => ({});
 
 export const getDebugger = (modelName: string, debuggerOperation: SpeedGooseDebuggerOperations): CustomDebugger => {
     if (isDebuggingEnabled(modelName, debuggerOperation)) {
-        const debug = DebuggerUtils.debug(`${DEFAULT_DEBUGGER_NAMESPACE}:${modelName}:${debuggerOperation}`);
+        const config = getConfig();
+        const namespace = `${DEFAULT_DEBUGGER_NAMESPACE}:${modelName}:${debuggerOperation}`;
 
+        // Use custom logger if provided
+        if (config?.debugConfig?.customLogger) {
+            return (label: string, ...dataToLog: unknown[]) => {
+                config.debugConfig!.customLogger!(namespace, label, ...dataToLog);
+            };
+        }
+
+        // Fallback to debug library
+        const debug = DebuggerUtils.debug(namespace);
         return (label: string, ...dataToLog: unknown[]) => debug(getLabelBackgroundColor(debug), label, '\x1b[0m', ...dataToLog);
     }
     return emptyDebugCallback;

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -23,6 +23,7 @@ const prepareConfig = (config: SpeedGooseConfig): void => {
         enabled: config?.debugConfig?.enabled ?? false,
         debugModels: config?.debugConfig?.debugModels ?? undefined,
         debugOperations: config?.debugConfig?.debugOperations ?? undefined,
+        customLogger: config?.debugConfig?.customLogger ?? undefined,
     };
     config.sharedCacheStrategy = config.sharedCacheStrategy ?? SharedCacheStrategies.REDIS;
     config.defaultTtl = config.defaultTtl ?? 60;


### PR DESCRIPTION
## Summary
- Closes #70
- Adds optional `customLogger` callback to debugConfig
- When provided, all debug output routes to the custom logger instead of the debug library
- Fully backward compatible - existing setups work without changes

## Usage

```typescript
import winston from 'winston';

const logger = winston.createLogger({
    level: 'debug',
    format: winston.format.json(),
    transports: [new winston.transports.Console()],
});

applySpeedGooseCacheLayer(mongoose, {
    debugConfig: {
        enabled: true,
        customLogger: (namespace, message, ...data) => {
            logger.debug({ namespace, message, data });
        },
    },
});
```

## Changes
- `src/types/types.ts` - Added `customLogger` property to debugConfig interface
- `src/utils/debugUtils.ts` - Modified `getDebugger()` to use custom logger when provided
- `src/wrapper.ts` - Include customLogger in config preparation
- `test/utils/debuggerUtils.test.ts` - Added 6 tests for custom logger functionality

## Test plan
- [x] All existing tests pass (191 tests)
- [x] New tests for custom logger functionality
- [x] Respects `debugModels` and `debugOperations` filters
- [x] Falls back to debug library when customLogger not provided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Custom logger configuration: Configure a custom logging callback function to handle debug logs instead of using the default debug library, enabling seamless integration with your preferred logging solutions.

* **Tests**
  * Added comprehensive test suite validating custom logger functionality, including proper namespace handling, multiple data argument forwarding, and compatibility with all debug filtering options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->