### PR TITLE
feat: mongoose 9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,32 @@ It's caching on two levels. Shared - with Redis. And local inside memory. Suppor
 -   It has a `cachePopulate` method that solves the N+1 problem with Mongoose population.
 <p align="right">(<a href="#top">back to top</a>)</p>
 
-## Release Note: 
-For now the latests version is on top of mongoose 8.8.0 and is tagged as beta. If you're facing any issues please use version 2.0.13 - it's compatible with mongoose 7.
+## Compatibility
+
+| Speedgoose | Mongoose | Node.js |
+|------------|----------|---------|
+| 2.x (latest) | 9.x   | >= 20.19 |
+| 2.x        | 8.x      | >= 16    |
+| 1.x        | 7.x      | >= 14    |
+
+## Performance
+
+Speedgoose delivers **massive speedups** on cached reads. Benchmarks below were run against an in-memory MongoDB (mongodb-memory-server) with 500 users and 1,000 posts with relations, using the IN_MEMORY cache strategy.
+
+| Operation | Uncached | Cached | Speedup |
+|-----------|----------|--------|---------|
+| `findOne` | ~1.4 ms  | ~0.03 ms | **~50x** |
+| `find` (20 results) | ~1.5 ms | ~0.02 ms | **~75x** |
+| `aggregate` ($group) | ~3.9 ms | ~0.02 ms | **~200x** |
+| `populate` (10 docs) | ~4.4 ms | ~0.02 ms | **~230x** |
+
+> Results may vary depending on hardware, dataset size, and query complexity. With Redis or DragonflyDB as the shared cache, latencies will be slightly higher than in-memory but still significantly faster than hitting MongoDB directly.
+
+Run the benchmarks yourself:
+
+```console
+yarn benchmark
+```
 
 <!-- GETTING STARTED -->
 
@@ -400,7 +424,7 @@ For example, if a `User` document is updated, any `Article` documents that have 
 -   [x] Refreshing TTL on read
 -   [x] Support for clustered servers 
 -   [x] Flowchart of logic
--   [ ] Tests
+-   [x] Tests
     -   [x] commonUtils
     -   [x] debuggerUtils
     -   [x] mongooseUtils
@@ -409,12 +433,14 @@ For example, if a `User` document is updated, any `Article` documents that have 
     -   [x] cacheKeyUtils
     -   [x] hydrationUtils
     -   [x] redisUtils
-    -   [ ] extendAggregate
-    -   [ ] extendQuery
-    -   [ ] mongooseModelEvents
+    -   [x] extendAggregate
+    -   [x] extendQuery
+    -   [x] mongooseModelEvents
     -   [x] wrapper
     -   [x] inMemory caching strategy
     -   [x] Redis caching strategy
+    -   [x] Integration / real-world app tests
+    -   [x] Performance benchmarks
 -   [x] Multitenancy (tenant field indicator) support
 -   [x] Debugging mode
 -   [x] Support for more cache storage

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "fastq": "^1.20.1",
                 "ioredis": "^5.9.2",
                 "keyv": "^4.5.4",
-                "mongoose": "^8.21.1",
+                "mongoose": "^9.2.0",
                 "mpath": "^0.9.0",
                 "typedi": "^0.10.0"
             },
@@ -2980,6 +2980,7 @@
             "version": "11.0.5",
             "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
             "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/webidl-conversions": "*"
@@ -3951,6 +3952,7 @@
             "version": "6.10.4",
             "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
             "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=16.20.1"
@@ -8206,12 +8208,12 @@
             }
         },
         "node_modules/kareem": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
-            "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/kareem/-/kareem-3.2.0.tgz",
+            "integrity": "sha512-VS8MWZz/cT+SqBCpVfNN4zoVz5VskR3N4+sTmUXme55e9avQHntpwpNq0yjnosISXqwJ3AQVjlbI4Dyzv//JtA==",
             "license": "Apache-2.0",
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/keyv": {
@@ -9432,6 +9434,7 @@
             "version": "6.20.0",
             "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
             "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@mongodb-js/saslprep": "^1.3.0",
@@ -9478,6 +9481,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
             "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/whatwg-url": "^11.0.2",
@@ -9537,25 +9541,101 @@
             }
         },
         "node_modules/mongoose": {
-            "version": "8.21.1",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.21.1.tgz",
-            "integrity": "sha512-1LhrVeHwiyAGxwSaYSq2uf32izQD+qoM2c8wq63W8MIsJBxKQDBnMkhJct55m0qqCsm2Maq8aPpIIfOHSYAqxg==",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.2.0.tgz",
+            "integrity": "sha512-lc1uFbtZHp1FqP8UCzRs9JZLhbBEmDt1l6B2MYmbD07Lp99yppQUwg2yPPyB3NO18EE5nQAoGCRiTf5v6vuJBQ==",
             "license": "MIT",
             "dependencies": {
-                "bson": "^6.10.4",
-                "kareem": "2.6.3",
-                "mongodb": "~6.20.0",
+                "kareem": "3.2.0",
+                "mongodb": "~7.0",
                 "mpath": "0.9.0",
-                "mquery": "5.0.0",
+                "mquery": "6.0.0",
                 "ms": "2.1.3",
                 "sift": "17.1.3"
             },
             "engines": {
-                "node": ">=16.20.1"
+                "node": ">=20.19.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mongoose"
+            }
+        },
+        "node_modules/mongoose/node_modules/@types/whatwg-url": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+            "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/webidl-conversions": "*"
+            }
+        },
+        "node_modules/mongoose/node_modules/bson": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
+            "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/mongoose/node_modules/mongodb": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.0.0.tgz",
+            "integrity": "sha512-vG/A5cQrvGGvZm2mTnCSz1LUcbOPl83hfB6bxULKQ8oFZauyox/2xbZOoGNl+64m8VBrETkdGCDBdOsCr3F3jg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@mongodb-js/saslprep": "^1.3.0",
+                "bson": "^7.0.0",
+                "mongodb-connection-string-url": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/credential-providers": "^3.806.0",
+                "@mongodb-js/zstd": "^7.0.0",
+                "gcp-metadata": "^7.0.1",
+                "kerberos": "^7.0.0",
+                "mongodb-client-encryption": ">=7.0.0 <7.1.0",
+                "snappy": "^7.3.2",
+                "socks": "^2.8.6"
+            },
+            "peerDependenciesMeta": {
+                "@aws-sdk/credential-providers": {
+                    "optional": true
+                },
+                "@mongodb-js/zstd": {
+                    "optional": true
+                },
+                "gcp-metadata": {
+                    "optional": true
+                },
+                "kerberos": {
+                    "optional": true
+                },
+                "mongodb-client-encryption": {
+                    "optional": true
+                },
+                "snappy": {
+                    "optional": true
+                },
+                "socks": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/mongoose/node_modules/mongodb-connection-string-url": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
+            "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/whatwg-url": "^13.0.0",
+                "whatwg-url": "^14.1.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
             }
         },
         "node_modules/mpath": {
@@ -9568,15 +9648,12 @@
             }
         },
         "node_modules/mquery": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
-            "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/mquery/-/mquery-6.0.0.tgz",
+            "integrity": "sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==",
             "license": "MIT",
-            "dependencies": {
-                "debug": "4.x"
-            },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.19.0"
             }
         },
         "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     },
     "scripts": {
         "test": "jest --forceExit",
+        "benchmark": "jest --testPathPattern=benchmark --forceExit --testTimeout=120000",
         "test:debug": "jest --runInBand --forceExit",
         "test-watch": "nodemon --exec 'npm test'",
         "clean": "rimraf ./lib/*",
@@ -57,7 +58,7 @@
         "fastq": "^1.20.1",
         "ioredis": "^5.9.2",
         "keyv": "^4.5.4",
-        "mongoose": "^8.21.1",
+        "mongoose": "^9.2.0",
         "mpath": "^0.9.0",
         "typedi": "^0.10.0"
     },
@@ -93,6 +94,9 @@
     },
     "bugs": {
         "url": "https://github.com/arqo123/speedgoose/issues"
+    },
+    "engines": {
+        "node": ">=20.19.0"
     },
     "homepage": "https://github.com/arqo123/speedgoose#readme",
     "directories": {

--- a/src/cachingStrategies/commonCacheStrategyAbstract.ts
+++ b/src/cachingStrategies/commonCacheStrategyAbstract.ts
@@ -1,7 +1,7 @@
 import { CachedResult } from '../types/types';
 
 export abstract class CommonCacheStrategyAbstract {
-    public abstract getValueFromCache(namespace: string, key: string): Promise<CachedResult>;
+    public abstract getValueFromCache(namespace: string, key: string): Promise<CachedResult | null>;
     public abstract isValueCached(namespace: string, key: string): Promise<boolean>;
     public abstract getValuesFromCachedSet(namespace: string): Promise<string[]>;
     public abstract addValueToCache<T>(namespace: string, key: string, value: CachedResult<T>, ttl?: number): Promise<void>;

--- a/src/cachingStrategies/inMemoryStrategy.ts
+++ b/src/cachingStrategies/inMemoryStrategy.ts
@@ -19,11 +19,11 @@ export class InMemoryStrategy extends CommonCacheStrategyAbstract {
         Container.set<InMemoryStrategy>(GlobalDiContainerRegistryNames.CACHE_CLIENT_GLOBAL_ACCESS, strategy);
     }
 
-    public async getValueFromCache(namespace: string, key: string): Promise<CachedResult> {
+    public async getValueFromCache(namespace: string, key: string): Promise<CachedResult | null> {
         const keyWithNamespace = `${namespace}:${key}`;
         const result = await this.resultsCacheClient.get(keyWithNamespace)
 
-        return result || null;
+        return (result ?? null) as CachedResult | null;
     }
 
     public async isValueCached(namespace: string, key: string): Promise<boolean> {

--- a/src/cachingStrategies/redisStrategy.ts
+++ b/src/cachingStrategies/redisStrategy.ts
@@ -14,7 +14,7 @@ export class RedisStrategy extends CommonCacheStrategyAbstract {
         Container.set<RedisStrategy>(GlobalDiContainerRegistryNames.CACHE_CLIENT_GLOBAL_ACCESS, strategy);
     }
 
-    public async getValueFromCache(namespace: string, key: string): Promise<CachedResult> {
+    public async getValueFromCache(namespace: string, key: string): Promise<CachedResult | null> {
         const keyWithNamespace = `${namespace}:${key}`;
 
         const result = await this.client.get(keyWithNamespace);

--- a/src/types/mongoose.ts
+++ b/src/types/mongoose.ts
@@ -1,18 +1,16 @@
 import { SpeedGooseCacheOperationParams, SpeedGoosePopulateOptions } from './types';
 
 declare module 'mongoose' {
-    //@ts-expect-error overwriting of mongoose Query interface
-    interface Query<ResultType, DocType, THelpers = {}, RawDocType = DocType> extends Query<ResultType, DocType> {
-        cacheQuery(params?: SpeedGooseCacheOperationParams): Promise<Query<ResultType, DocType, unknown>>;
+    interface Query<ResultType, DocType, THelpers = {}, RawDocType = unknown, QueryOp = 'find', TDocOverrides = Record<string, never>> {
+        cacheQuery(params?: SpeedGooseCacheOperationParams): Promise<ResultType>;
         isCached(params?: SpeedGooseCacheOperationParams): Promise<boolean>;
         /** New method for cached population */
         cachePopulate(options: string | SpeedGoosePopulateOptions | SpeedGoosePopulateOptions[]): this;
         mongooseCollection: Collection;
         op: string;
     }
-    //@ts-expect-error overwriting of mongoose Aggregate interface
-    interface Aggregate<R, ResultType> extends Aggregate<R> {
-        cachePipeline(params?: SpeedGooseCacheOperationParams): Promise<R>;
+    interface Aggregate<ResultType> {
+        cachePipeline(params?: SpeedGooseCacheOperationParams): Promise<ResultType>;
         isCached(params?: SpeedGooseCacheOperationParams): Promise<boolean>;
         _model: Model<unknown>;
     }
@@ -20,8 +18,7 @@ declare module 'mongoose' {
     // interface SchemaType extends SchemaType {
     //     //options: SchemaTypeOptions<any>
     // }
-    //@ts-expect-error overwriting of mongoose SchemaType interface
-    interface Schema extends Schema {
+    interface Schema {
         plugins: { fn: typeof Function; opts: Record<string, never> }[];
     }
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,11 +1,11 @@
 import Keyv from 'keyv';
 import './mongoose';
-import { Aggregate, Document, ObjectId } from 'mongoose';
+import { Document, ObjectId } from 'mongoose';
 import { RedisStrategy } from '../cachingStrategies/redisStrategy';
 import { InMemoryStrategy } from '../cachingStrategies/inMemoryStrategy';
 import { RedisOptions } from 'ioredis';
 
-export type AggregationResult = Aggregate<unknown, unknown>;
+export type AggregationResult = unknown[];
 export type CachedDocument<T> = Document<string | ObjectId> & T;
 export type CachedLeanDocument<T> = T & { _id: ObjectId | string };
 export type DocumentWithIdAndTenantValue = { _id: string; [tenantId: string]: string };

--- a/src/utils/cacheClientUtils.ts
+++ b/src/utils/cacheClientUtils.ts
@@ -114,7 +114,7 @@ export const createInMemoryCacheClientWithNamespace = <T>(namespace: string) =>
         },
     );
 
-export const getResultsFromCache = async (key: string): Promise<CachedResult> => getCacheStrategyInstance().getValueFromCache(CacheNamespaces.RESULTS_NAMESPACE, key);
+export const getResultsFromCache = async (key: string): Promise<CachedResult | null> => getCacheStrategyInstance().getValueFromCache(CacheNamespaces.RESULTS_NAMESPACE, key);
 
 export const isCached = async (key: string): Promise<boolean> => getCacheStrategyInstance().isValueCached(CacheNamespaces.RESULTS_NAMESPACE, key);
 

--- a/src/utils/cacheKeyUtils.ts
+++ b/src/utils/cacheKeyUtils.ts
@@ -15,7 +15,7 @@ export const generateCacheKeyFromQuery = <T>(query: Query<T, T>): string =>
         customStringifyReplacer,
     );
 
-export const generateCacheKeyFromPipeline = <R>(aggregation: Aggregate<R[], R>): string =>
+export const generateCacheKeyFromPipeline = <R>(aggregation: Aggregate<R>): string =>
     JSON.stringify(
         {
             pipeline: aggregation.pipeline(),

--- a/src/utils/hydrationUtils.ts
+++ b/src/utils/hydrationUtils.ts
@@ -23,7 +23,6 @@ export const getReferenceModelNameFromSchema = (schema: SchemaType): string => {
 const getFieldsToHydrate = <T>(model: Model<T>): FieldWithReferenceModel[] =>
     Object.entries<SchemaType>({
         ...(model?.schema?.paths ?? {}),
-        //@ts-expect-error singleNestedPaths might be not available in some of mongoose versions
         ...(model?.schema?.singleNestedPaths ?? {}),
     })
         .map(([path, schemaFieldType]) => ({ path, referenceModelName: getReferenceModelNameFromSchema(schemaFieldType) }))

--- a/src/utils/queryUtils.ts
+++ b/src/utils/queryUtils.ts
@@ -40,7 +40,7 @@ export const prepareQueryOperationContext = <T>(query: Query<T, T>, context: Spe
     context.debug = getDebugger(query.model.modelName, SpeedGooseDebuggerOperations.CACHE_QUERY);
 };
 
-export const prepareAggregateOperationParams = <R>(aggregation: Aggregate<R[], R>, context: SpeedGooseCacheOperationContext): void => {
+export const prepareAggregateOperationParams = <R>(aggregation: Aggregate<R>, context: SpeedGooseCacheOperationContext): void => {
     const config = getConfig();
 
     if (config?.defaultTtl) {

--- a/test/benchmark/performance.test.ts
+++ b/test/benchmark/performance.test.ts
@@ -1,0 +1,395 @@
+import mongoose, { Schema, Model, Document } from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import Container from 'typedi';
+import { applySpeedGooseCacheLayer } from '../../src/wrapper';
+import { SpeedGooseCacheAutoCleaner } from '../../src/plugin/SpeedGooseCacheAutoCleaner';
+import { SharedCacheStrategies } from '../../src/types/types';
+import { clearAllCaches } from '../../src/utils/cacheUtils';
+
+jest.setTimeout(120000);
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface IBenchUser extends Document {
+    name: string;
+    email: string;
+    age: number;
+    createdAt: Date;
+}
+
+interface IBenchPost extends Document {
+    title: string;
+    content: string;
+    author: IBenchUser | mongoose.Types.ObjectId;
+    tags: string[];
+    createdAt: Date;
+}
+
+interface BenchmarkStats {
+    ops_per_sec: number;
+    avg_ms: number;
+    p50_ms: number;
+    p95_ms: number;
+    p99_ms: number;
+    min_ms: number;
+    max_ms: number;
+}
+
+// ─── Statistics helper ───────────────────────────────────────────────────────
+
+function computeStats(timingsNs: bigint[]): BenchmarkStats {
+    if (timingsNs.length === 0) {
+        return { ops_per_sec: 0, avg_ms: 0, p50_ms: 0, p95_ms: 0, p99_ms: 0, min_ms: 0, max_ms: 0 };
+    }
+
+    const sorted = [...timingsNs].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    const toMs = (ns: bigint) => Number(ns) / 1_000_000;
+
+    const sum = sorted.reduce((acc, v) => acc + v, 0n);
+    const avg_ms = toMs(sum / BigInt(sorted.length));
+    const p50_ms = toMs(sorted[Math.floor(sorted.length * 0.5)]);
+    const p95_ms = toMs(sorted[Math.min(Math.floor(sorted.length * 0.95), sorted.length - 1)]);
+    const p99_ms = toMs(sorted[Math.min(Math.floor(sorted.length * 0.99), sorted.length - 1)]);
+    const min_ms = toMs(sorted[0]);
+    const max_ms = toMs(sorted[sorted.length - 1]);
+    const ops_per_sec = avg_ms > 0 ? Math.round(1000 / avg_ms) : 0;
+
+    return { ops_per_sec, avg_ms: round(avg_ms), p50_ms: round(p50_ms), p95_ms: round(p95_ms), p99_ms: round(p99_ms), min_ms: round(min_ms), max_ms: round(max_ms) };
+}
+
+function round(n: number, decimals = 3): number {
+    const f = Math.pow(10, decimals);
+    return Math.round(n * f) / f;
+}
+
+// ─── Pretty-print helper ────────────────────────────────────────────────────
+
+function printBenchmarkPair(label: string, uncachedStats: BenchmarkStats, cachedStats: BenchmarkStats): void {
+    const speedup = uncachedStats.avg_ms > 0 && cachedStats.avg_ms > 0
+        ? round(uncachedStats.avg_ms / cachedStats.avg_ms, 1)
+        : 0;
+
+    const rows = [
+        { Benchmark: `${label} (uncached)`, 'Avg (ms)': uncachedStats.avg_ms, 'P95 (ms)': uncachedStats.p95_ms, 'Ops/sec': uncachedStats.ops_per_sec, Speedup: '-' },
+        { Benchmark: `${label} (cached)`, 'Avg (ms)': cachedStats.avg_ms, 'P95 (ms)': cachedStats.p95_ms, 'Ops/sec': cachedStats.ops_per_sec, Speedup: `${speedup}x` },
+    ];
+
+    console.log(`\n--- ${label} ---`);
+    console.table(rows);
+}
+
+function printSingleBenchmark(label: string, stats: BenchmarkStats): void {
+    console.log(`\n--- ${label} ---`);
+    console.table([{ Benchmark: label, 'Avg (ms)': stats.avg_ms, 'P95 (ms)': stats.p95_ms, 'Ops/sec': stats.ops_per_sec }]);
+}
+
+// ─── Test suite ──────────────────────────────────────────────────────────────
+
+describe('Performance Benchmarks', () => {
+    let mongoServer: MongoMemoryServer;
+    let BenchUser: Model<IBenchUser>;
+    let BenchPost: Model<IBenchPost>;
+    let userIds: mongoose.Types.ObjectId[] = [];
+    let userNames: string[] = [];
+
+    const SEED_USERS = 500;
+    const SEED_POSTS = 1000;
+    const WARMUP_ITERATIONS = 5;
+    const TAGS = ['tech', 'science', 'sports', 'music', 'art', 'travel', 'food', 'health', 'finance', 'education'];
+
+    beforeAll(async () => {
+        // Start in-memory MongoDB
+        mongoServer = await MongoMemoryServer.create();
+        const uri = mongoServer.getUri();
+
+        // Connect mongoose (disconnect first if already connected from global setup)
+        if (mongoose.connection.readyState !== 0) {
+            await mongoose.disconnect();
+        }
+        await mongoose.connect(uri);
+
+        // Reset DI container and apply cache layer
+        Container.reset();
+        await applySpeedGooseCacheLayer(mongoose, {
+            sharedCacheStrategy: SharedCacheStrategies.IN_MEMORY,
+            debugConfig: { enabled: false },
+            defaultTtl: 300,
+        });
+
+        // Define schemas with auto-cleaner plugin
+        const benchUserSchema = new Schema<IBenchUser>({
+            name: { type: String, required: true, index: true },
+            email: { type: String, required: true },
+            age: { type: Number, required: true },
+            createdAt: { type: Date, default: Date.now },
+        });
+        benchUserSchema.plugin(SpeedGooseCacheAutoCleaner);
+
+        const benchPostSchema = new Schema<IBenchPost>({
+            title: { type: String, required: true },
+            content: { type: String, required: true },
+            author: { type: Schema.Types.ObjectId, ref: 'BenchUser', required: true, index: true },
+            tags: [{ type: String }],
+            createdAt: { type: Date, default: Date.now },
+        });
+        benchPostSchema.plugin(SpeedGooseCacheAutoCleaner);
+
+        BenchUser = mongoose.models['BenchUser'] ?? mongoose.model<IBenchUser>('BenchUser', benchUserSchema);
+        BenchPost = mongoose.models['BenchPost'] ?? mongoose.model<IBenchPost>('BenchPost', benchPostSchema);
+
+        // Seed data
+        console.log(`Seeding ${SEED_USERS} users and ${SEED_POSTS} posts...`);
+        const seedStart = process.hrtime.bigint();
+
+        const userDocs = [];
+        for (let i = 0; i < SEED_USERS; i++) {
+            userDocs.push({
+                name: `User_${i}`,
+                email: `user${i}@bench.test`,
+                age: 18 + (i % 60),
+            });
+        }
+        const insertedUsers = await BenchUser.insertMany(userDocs);
+        userIds = insertedUsers.map(u => u._id as mongoose.Types.ObjectId);
+        userNames = insertedUsers.map(u => u.name);
+
+        const postDocs = [];
+        for (let i = 0; i < SEED_POSTS; i++) {
+            const authorIdx = i % SEED_USERS;
+            const tagCount = 1 + (i % 4);
+            const postTags = [];
+            for (let t = 0; t < tagCount; t++) {
+                postTags.push(TAGS[(i + t) % TAGS.length]);
+            }
+            postDocs.push({
+                title: `Post Title ${i}`,
+                content: `This is the content of post number ${i}. It contains enough text to be realistic.`,
+                author: userIds[authorIdx],
+                tags: postTags,
+            });
+        }
+        await BenchPost.insertMany(postDocs);
+
+        const seedElapsed = Number(process.hrtime.bigint() - seedStart) / 1_000_000;
+        console.log(`Seeding completed in ${round(seedElapsed)}ms`);
+    }, 60000);
+
+    afterAll(async () => {
+        await mongoose.disconnect();
+        await mongoServer.stop();
+    });
+
+    async function clearCache(): Promise<void> {
+        await clearAllCaches();
+    }
+
+    // ─── Benchmark 1: findOne — uncached vs cached ─────────────────────────
+
+    it('findOne — uncached vs cached', async () => {
+        const iterations = 50;
+
+        // --- Uncached ---
+        await clearCache();
+        // Warmup
+        for (let i = 0; i < WARMUP_ITERATIONS; i++) {
+            await BenchUser.findOne({ name: userNames[i % userNames.length] });
+        }
+
+        const uncachedTimings: bigint[] = [];
+        for (let i = 0; i < iterations; i++) {
+            const name = userNames[i % userNames.length];
+            const start = process.hrtime.bigint();
+            await BenchUser.findOne({ name });
+            uncachedTimings.push(process.hrtime.bigint() - start);
+        }
+
+        // --- Cached ---
+        await clearCache();
+        // Warmup (cold cache fills)
+        for (let i = 0; i < WARMUP_ITERATIONS; i++) {
+            await (BenchUser.findOne({ name: userNames[i % userNames.length] }) as any).cacheQuery();
+        }
+
+        const cachedTimings: bigint[] = [];
+        for (let i = 0; i < iterations; i++) {
+            const name = userNames[i % WARMUP_ITERATIONS]; // reuse warmed-up queries
+            const start = process.hrtime.bigint();
+            await (BenchUser.findOne({ name }) as any).cacheQuery();
+            cachedTimings.push(process.hrtime.bigint() - start);
+        }
+
+        const uncachedStats = computeStats(uncachedTimings);
+        const cachedStats = computeStats(cachedTimings);
+        printBenchmarkPair('findOne', uncachedStats, cachedStats);
+
+        // Cached should be faster on average
+        expect(cachedStats.avg_ms).toBeLessThan(uncachedStats.avg_ms);
+    }, 60000);
+
+    // ─── Benchmark 2: find (multiple results) — uncached vs cached ─────────
+
+    it('find (multiple results) — uncached vs cached', async () => {
+        const iterations = 50;
+
+        // --- Uncached ---
+        await clearCache();
+        // Warmup
+        for (let i = 0; i < WARMUP_ITERATIONS; i++) {
+            await BenchPost.find({ author: userIds[i % userIds.length] }).limit(20);
+        }
+
+        const uncachedTimings: bigint[] = [];
+        for (let i = 0; i < iterations; i++) {
+            const userId = userIds[i % userIds.length];
+            const start = process.hrtime.bigint();
+            await BenchPost.find({ author: userId }).limit(20);
+            uncachedTimings.push(process.hrtime.bigint() - start);
+        }
+
+        // --- Cached ---
+        await clearCache();
+        // Warmup (cold cache fills)
+        for (let i = 0; i < WARMUP_ITERATIONS; i++) {
+            await (BenchPost.find({ author: userIds[i % userIds.length] }).limit(20) as any).cacheQuery();
+        }
+
+        const cachedTimings: bigint[] = [];
+        for (let i = 0; i < iterations; i++) {
+            const userId = userIds[i % WARMUP_ITERATIONS]; // reuse warmed-up queries
+            const start = process.hrtime.bigint();
+            await (BenchPost.find({ author: userId }).limit(20) as any).cacheQuery();
+            cachedTimings.push(process.hrtime.bigint() - start);
+        }
+
+        const uncachedStats = computeStats(uncachedTimings);
+        const cachedStats = computeStats(cachedTimings);
+        printBenchmarkPair('find (multi)', uncachedStats, cachedStats);
+
+        expect(cachedStats.avg_ms).toBeLessThan(uncachedStats.avg_ms);
+    }, 60000);
+
+    // ─── Benchmark 3: Aggregate pipeline — uncached vs cached ──────────────
+
+    it('aggregate pipeline — uncached vs cached', async () => {
+        const iterations = 30;
+        const pipeline = [{ $group: { _id: '$author', count: { $sum: 1 } } }];
+
+        // --- Uncached ---
+        await clearCache();
+        // Warmup
+        for (let i = 0; i < WARMUP_ITERATIONS; i++) {
+            await BenchPost.aggregate(pipeline);
+        }
+
+        const uncachedTimings: bigint[] = [];
+        for (let i = 0; i < iterations; i++) {
+            const start = process.hrtime.bigint();
+            await BenchPost.aggregate(pipeline);
+            uncachedTimings.push(process.hrtime.bigint() - start);
+        }
+
+        // --- Cached ---
+        await clearCache();
+        // Warmup (cold cache fill)
+        await (BenchPost.aggregate(pipeline) as any).cachePipeline();
+
+        const cachedTimings: bigint[] = [];
+        for (let i = 0; i < iterations; i++) {
+            const start = process.hrtime.bigint();
+            await (BenchPost.aggregate(pipeline) as any).cachePipeline();
+            cachedTimings.push(process.hrtime.bigint() - start);
+        }
+
+        const uncachedStats = computeStats(uncachedTimings);
+        const cachedStats = computeStats(cachedTimings);
+        printBenchmarkPair('aggregate', uncachedStats, cachedStats);
+
+        expect(cachedStats.avg_ms).toBeLessThan(uncachedStats.avg_ms);
+    }, 60000);
+
+    // ─── Benchmark 4: Population — uncached vs cached ──────────────────────
+
+    it('population — uncached vs cached', async () => {
+        const iterations = 30;
+
+        // --- Uncached ---
+        await clearCache();
+        // Warmup
+        for (let i = 0; i < WARMUP_ITERATIONS; i++) {
+            await BenchPost.find().limit(10).populate('author');
+        }
+
+        const uncachedTimings: bigint[] = [];
+        for (let i = 0; i < iterations; i++) {
+            const start = process.hrtime.bigint();
+            await BenchPost.find().limit(10).populate('author');
+            uncachedTimings.push(process.hrtime.bigint() - start);
+        }
+
+        // --- Cached ---
+        await clearCache();
+        // Warmup (cold cache fill)
+        await (BenchPost.find().limit(10) as any).cachePopulate('author').cacheQuery();
+
+        const cachedTimings: bigint[] = [];
+        for (let i = 0; i < iterations; i++) {
+            const start = process.hrtime.bigint();
+            await (BenchPost.find().limit(10) as any).cachePopulate('author').cacheQuery();
+            cachedTimings.push(process.hrtime.bigint() - start);
+        }
+
+        const uncachedStats = computeStats(uncachedTimings);
+        const cachedStats = computeStats(cachedTimings);
+        printBenchmarkPair('populate', uncachedStats, cachedStats);
+
+        expect(cachedStats.avg_ms).toBeLessThan(uncachedStats.avg_ms);
+    }, 60000);
+
+    // ─── Benchmark 5: Cache invalidation overhead ──────────────────────────
+
+    it('cache invalidation overhead', async () => {
+        const iterations = 30;
+
+        // Warmup
+        for (let i = 0; i < WARMUP_ITERATIONS; i++) {
+            const tmpUser = await BenchUser.create({ name: `Warmup_${i}`, email: `warmup${i}@bench.test`, age: 25 });
+            await (BenchUser.findOne({ name: tmpUser.name }) as any).cacheQuery();
+            await BenchUser.updateOne({ _id: tmpUser._id }, { age: 99 });
+            // Small delay to allow async cache clearing
+            await new Promise(resolve => setTimeout(resolve, 50));
+        }
+
+        const timings: bigint[] = [];
+        for (let i = 0; i < iterations; i++) {
+            const start = process.hrtime.bigint();
+
+            // Create a new doc
+            const user = await BenchUser.create({ name: `InvalidationTest_${i}`, email: `inv${i}@bench.test`, age: 30 });
+
+            // Cache a query that returns this doc
+            await (BenchUser.findOne({ name: user.name }) as any).cacheQuery();
+
+            // Verify it is cached
+            const isCachedBefore = await (BenchUser.findOne({ name: user.name }) as any).isCached();
+            expect(isCachedBefore).toBe(true);
+
+            // Update the doc (triggers auto-invalidation via SpeedGooseCacheAutoCleaner)
+            await BenchUser.updateOne({ _id: user._id }, { age: 99 });
+
+            // Small delay to allow async cache invalidation to propagate
+            await new Promise(resolve => setTimeout(resolve, 50));
+
+            // Verify the cache was cleared
+            const isCachedAfter = await (BenchUser.findOne({ name: user.name }) as any).isCached();
+            expect(isCachedAfter).toBe(false);
+
+            timings.push(process.hrtime.bigint() - start);
+        }
+
+        const stats = computeStats(timings);
+        printSingleBenchmark('cache invalidation cycle', stats);
+
+        // Just verify it completed — the important thing is the invalidation works
+        expect(stats.avg_ms).toBeGreaterThan(0);
+    }, 60000);
+});

--- a/test/extendAggregate.test.ts
+++ b/test/extendAggregate.test.ts
@@ -1,0 +1,296 @@
+import mongoose from 'mongoose';
+import { applySpeedGooseCacheLayer } from '../src/wrapper';
+import { UserModel, setupTestDB, clearTestCache, generateTestAggregateQuery } from './testUtils';
+import * as cacheClientUtils from '../src/utils/cacheClientUtils';
+import * as commonUtils from '../src/utils/commonUtils';
+
+describe('extendAggregate', () => {
+    beforeAll(async () => {
+        await setupTestDB();
+        await applySpeedGooseCacheLayer(mongoose, {});
+    });
+
+    afterAll(async () => {
+        await mongoose.connection.close();
+        await mongoose.disconnect();
+    });
+
+    beforeEach(async () => {
+        await clearTestCache();
+        await UserModel.deleteMany({});
+    });
+
+    describe('cachePipeline() - caching enabled', () => {
+        beforeEach(async () => {
+            await UserModel.create([
+                { name: 'Alice', email: 'alice@test.com', age: 30 },
+                { name: 'Bob', email: 'bob@test.com', age: 25 },
+                { name: 'Charlie', email: 'charlie@test.com', age: 30 },
+            ]);
+        });
+
+        it('should return cached result on second call (cache hit)', async () => {
+            const pipeline = [{ $match: { age: 30 } }, { $sort: { name: 1 } }];
+
+            const firstResult = await generateTestAggregateQuery(pipeline).cachePipeline();
+            expect(firstResult).toHaveLength(2);
+
+            // Spy on getResultsFromCache to verify the second call returns from cache
+            const cacheSpy = jest.spyOn(cacheClientUtils, 'getResultsFromCache');
+
+            const secondResult = await generateTestAggregateQuery(pipeline).cachePipeline();
+            expect(secondResult).toHaveLength(2);
+            expect(secondResult).toEqual(firstResult);
+
+            // getResultsFromCache should have been called and returned a truthy value (cache hit)
+            expect(cacheSpy).toHaveBeenCalled();
+            const cacheReturnValue = await cacheSpy.mock.results[0].value;
+            expect(cacheReturnValue).toBeTruthy();
+
+            cacheSpy.mockRestore();
+        });
+
+        it('should fetch from DB on cache miss and store in cache', async () => {
+            const pipeline = [{ $match: { age: 25 } }];
+
+            const spy = jest.spyOn(cacheClientUtils, 'getResultsFromCache');
+
+            const result = await generateTestAggregateQuery(pipeline).cachePipeline();
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('Bob');
+
+            // First call should have returned null from cache (miss)
+            expect(spy).toHaveBeenCalled();
+
+            // Second call should hit cache
+            const cachedResult = await generateTestAggregateQuery(pipeline).cachePipeline();
+            expect(cachedResult).toHaveLength(1);
+            expect(cachedResult[0].name).toBe('Bob');
+
+            spy.mockRestore();
+        });
+
+        it('should work with $group pipeline', async () => {
+            const pipeline = [
+                { $group: { _id: '$age', count: { $sum: 1 } } },
+                { $sort: { _id: 1 } },
+            ];
+
+            const result = await generateTestAggregateQuery(pipeline).cachePipeline();
+            expect(result).toHaveLength(2);
+
+            const age25Group = result.find((r: any) => r._id === 25);
+            const age30Group = result.find((r: any) => r._id === 30);
+            expect(age25Group.count).toBe(1);
+            expect(age30Group.count).toBe(2);
+
+            // Verify cached result is the same
+            const cachedResult = await generateTestAggregateQuery(pipeline).cachePipeline();
+            expect(cachedResult).toEqual(result);
+        });
+
+        it('should work with $match pipeline', async () => {
+            const pipeline = [{ $match: { name: 'Alice' } }];
+
+            const result = await generateTestAggregateQuery(pipeline).cachePipeline();
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('Alice');
+        });
+
+        it('should work with $sort pipeline', async () => {
+            const pipeline = [{ $sort: { name: -1 } }];
+
+            const result = await generateTestAggregateQuery(pipeline).cachePipeline();
+            expect(result).toHaveLength(3);
+            expect(result[0].name).toBe('Charlie');
+            expect(result[1].name).toBe('Bob');
+            expect(result[2].name).toBe('Alice');
+        });
+
+        it('should accept custom TTL param', async () => {
+            const pipeline = [{ $match: { age: 30 } }];
+
+            const result = await generateTestAggregateQuery(pipeline).cachePipeline({ ttl: 120 });
+            expect(result).toHaveLength(2);
+
+            // Verify it is cached
+            const isCachedResult = await generateTestAggregateQuery(pipeline).isCached();
+            expect(isCachedResult).toBe(true);
+        });
+
+        it('should accept custom cacheKey param', async () => {
+            const pipeline = [{ $match: { age: 30 } }];
+            const customKey = 'my-custom-aggregate-key';
+
+            const result = await generateTestAggregateQuery(pipeline).cachePipeline({ cacheKey: customKey });
+            expect(result).toHaveLength(2);
+
+            // Verify it is cached with the custom key
+            const isCachedResult = await generateTestAggregateQuery(pipeline).isCached({ cacheKey: customKey });
+            expect(isCachedResult).toBe(true);
+        });
+
+        it('should return a plain array (not Aggregate object)', async () => {
+            const pipeline = [{ $match: { age: 30 } }];
+
+            const result = await generateTestAggregateQuery(pipeline).cachePipeline();
+            expect(Array.isArray(result)).toBe(true);
+            expect(result).toHaveLength(2);
+        });
+    });
+
+    describe('cachePipeline() - caching disabled', () => {
+        it('should fall through to regular exec() when caching is disabled', async () => {
+            await UserModel.create({ name: 'DisabledTest', email: 'disabled@test.com', age: 40 });
+
+            const spy = jest.spyOn(commonUtils, 'isCachingEnabled').mockReturnValue(false);
+
+            const pipeline = [{ $match: { age: 40 } }];
+            const result = await generateTestAggregateQuery(pipeline).cachePipeline();
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('DisabledTest');
+
+            // Should not be cached since caching is disabled
+            spy.mockRestore();
+            const isCachedResult = await generateTestAggregateQuery(pipeline).isCached();
+            expect(isCachedResult).toBe(false);
+        });
+    });
+
+    describe('isCached()', () => {
+        beforeEach(async () => {
+            await UserModel.create({ name: 'CacheCheckUser', email: 'cachecheck@test.com', age: 50 });
+        });
+
+        it('should return false when not cached', async () => {
+            const pipeline = [{ $match: { age: 50 } }];
+            const result = await generateTestAggregateQuery(pipeline).isCached();
+            expect(result).toBe(false);
+        });
+
+        it('should return true after cachePipeline()', async () => {
+            const pipeline = [{ $match: { age: 50 } }];
+
+            await generateTestAggregateQuery(pipeline).cachePipeline();
+
+            const result = await generateTestAggregateQuery(pipeline).isCached();
+            expect(result).toBe(true);
+        });
+    });
+
+    describe('execAggregationWithCache flow', () => {
+        beforeEach(async () => {
+            await UserModel.create([
+                { name: 'FlowUser1', email: 'flow1@test.com', age: 60 },
+                { name: 'FlowUser2', email: 'flow2@test.com', age: 70 },
+            ]);
+        });
+
+        it('should call refreshTTLTimeIfNeeded on cache hit', async () => {
+            const spy = jest.spyOn(cacheClientUtils, 'refreshTTLTimeIfNeeded');
+
+            const pipeline = [{ $match: { age: 60 } }];
+
+            // First call - cache miss, no TTL refresh
+            await generateTestAggregateQuery(pipeline).cachePipeline();
+            spy.mockClear();
+
+            // Second call - cache hit, should refresh TTL
+            await generateTestAggregateQuery(pipeline).cachePipeline();
+            expect(spy).toHaveBeenCalled();
+
+            spy.mockRestore();
+        });
+
+        it('should call setKeyInResultsCaches on cache miss', async () => {
+            const spy = jest.spyOn(cacheClientUtils, 'setKeyInResultsCaches');
+
+            const pipeline = [{ $match: { age: 70 } }];
+
+            await generateTestAggregateQuery(pipeline).cachePipeline();
+
+            expect(spy).toHaveBeenCalled();
+            spy.mockRestore();
+        });
+
+        it('should generate different cache keys for different pipelines', async () => {
+            const pipeline1 = [{ $match: { age: 60 } }];
+            const pipeline2 = [{ $match: { age: 70 } }];
+
+            const result1 = await generateTestAggregateQuery(pipeline1).cachePipeline();
+            expect(result1).toHaveLength(1);
+            expect(result1[0].name).toBe('FlowUser1');
+
+            const result2 = await generateTestAggregateQuery(pipeline2).cachePipeline();
+            expect(result2).toHaveLength(1);
+            expect(result2[0].name).toBe('FlowUser2');
+
+            // Verify each returns its own cached result (from cache, not DB)
+            const cacheSpy = jest.spyOn(cacheClientUtils, 'getResultsFromCache');
+
+            const cachedResult1 = await generateTestAggregateQuery(pipeline1).cachePipeline();
+            const cachedResult2 = await generateTestAggregateQuery(pipeline2).cachePipeline();
+
+            expect(cachedResult1[0].name).toBe('FlowUser1');
+            expect(cachedResult2[0].name).toBe('FlowUser2');
+
+            // Both calls should have been cache hits
+            expect(cacheSpy).toHaveBeenCalledTimes(2);
+            const cacheReturn1 = await cacheSpy.mock.results[0].value;
+            const cacheReturn2 = await cacheSpy.mock.results[1].value;
+            expect(cacheReturn1).toBeTruthy();
+            expect(cacheReturn2).toBeTruthy();
+
+            cacheSpy.mockRestore();
+        });
+    });
+
+    describe('Edge cases', () => {
+        it('should cache empty result set correctly', async () => {
+            const pipeline = [{ $match: { age: 999 } }];
+
+            const result = await generateTestAggregateQuery(pipeline).cachePipeline();
+            expect(result).toEqual([]);
+
+            // Should be cached even though empty
+            const isCachedResult = await generateTestAggregateQuery(pipeline).isCached();
+            expect(isCachedResult).toBe(true);
+
+            // Should return empty array from cache
+            const cachedResult = await generateTestAggregateQuery(pipeline).cachePipeline();
+            expect(cachedResult).toEqual([]);
+        });
+
+        it('should not have different pipelines on same model interfere with each other', async () => {
+            await UserModel.create([
+                { name: 'EdgeUser1', email: 'edge1@test.com', age: 80 },
+                { name: 'EdgeUser2', email: 'edge2@test.com', age: 90 },
+            ]);
+
+            const pipeline1 = [{ $match: { age: 80 } }];
+            const pipeline2 = [{ $match: { age: 90 } }];
+            const pipeline3 = [{ $group: { _id: '$age', count: { $sum: 1 } } }];
+
+            const result1 = await generateTestAggregateQuery(pipeline1).cachePipeline();
+            const result2 = await generateTestAggregateQuery(pipeline2).cachePipeline();
+            const result3 = await generateTestAggregateQuery(pipeline3).cachePipeline();
+
+            expect(result1).toHaveLength(1);
+            expect(result1[0].name).toBe('EdgeUser1');
+
+            expect(result2).toHaveLength(1);
+            expect(result2[0].name).toBe('EdgeUser2');
+
+            expect(result3).toHaveLength(2);
+
+            // Verify each pipeline returns its own cached result independently
+            const cachedResult1 = await generateTestAggregateQuery(pipeline1).cachePipeline();
+            const cachedResult2 = await generateTestAggregateQuery(pipeline2).cachePipeline();
+            const cachedResult3 = await generateTestAggregateQuery(pipeline3).cachePipeline();
+
+            expect(cachedResult1).toEqual(result1);
+            expect(cachedResult2).toEqual(result2);
+            expect(cachedResult3).toEqual(result3);
+        });
+    });
+});

--- a/test/extendQuery.test.ts
+++ b/test/extendQuery.test.ts
@@ -1,0 +1,293 @@
+import mongoose from 'mongoose';
+import { applySpeedGooseCacheLayer } from '../src/wrapper';
+import { UserModel, setupTestDB, clearTestCache } from './testUtils';
+import * as commonUtils from '../src/utils/commonUtils';
+import * as cacheClientUtils from '../src/utils/cacheClientUtils';
+
+describe('extendQuery', () => {
+    beforeAll(async () => {
+        await setupTestDB();
+        await applySpeedGooseCacheLayer(mongoose, {
+            sharedCacheStrategy: 'inMemory' as any,
+            redisUri: 'redis://localhost:6379',
+            debugConfig: { enabled: false },
+        });
+    });
+
+    afterAll(async () => {
+        await mongoose.connection.close();
+        await mongoose.disconnect();
+    });
+
+    beforeEach(async () => {
+        await clearTestCache();
+        await UserModel.deleteMany({});
+    });
+
+    describe('cacheQuery()', () => {
+        describe('when caching is enabled', () => {
+            it('should return cached result on cache hit (second call returns same data)', async () => {
+                const user = await UserModel.create({ name: 'CacheHitUser', email: 'cachehit@test.com' });
+
+                const firstResult = await UserModel.findOne({ _id: user._id }).cacheQuery();
+                expect(firstResult).toBeDefined();
+                expect(firstResult!.name).toBe('CacheHitUser');
+
+                // Second call should return cached result
+                const secondResult = await UserModel.findOne({ _id: user._id }).cacheQuery();
+                expect(secondResult).toBeDefined();
+                expect(secondResult!.name).toBe('CacheHitUser');
+            });
+
+            it('should fetch from DB on cache miss and store in cache', async () => {
+                const user = await UserModel.create({ name: 'CacheMissUser', email: 'cachemiss@test.com' });
+
+                // First call: cache miss, should fetch from DB
+                const result = await UserModel.findOne({ _id: user._id }).cacheQuery();
+                expect(result).toBeDefined();
+                expect(result!.name).toBe('CacheMissUser');
+
+                // Verify it's now in cache
+                const isCachedResult = await UserModel.findOne({ _id: user._id }).isCached();
+                expect(isCachedResult).toBe(true);
+            });
+
+            it('should work with findOne queries', async () => {
+                const user = await UserModel.create({ name: 'FindOneUser', email: 'findone@test.com' });
+
+                const result = await UserModel.findOne({ _id: user._id }).cacheQuery();
+                expect(result).toBeDefined();
+                expect(result!.name).toBe('FindOneUser');
+            });
+
+            it('should work with find queries', async () => {
+                await UserModel.create([
+                    { name: 'FindUser1', email: 'find1@test.com' },
+                    { name: 'FindUser2', email: 'find2@test.com' },
+                ]);
+
+                const results = await UserModel.find({}).cacheQuery();
+                expect(results).toBeDefined();
+                expect(Array.isArray(results)).toBe(true);
+                expect((results as any[]).length).toBe(2);
+            });
+
+            it('should work with countDocuments queries', async () => {
+                await UserModel.create([
+                    { name: 'CountUser1', email: 'count1@test.com' },
+                    { name: 'CountUser2', email: 'count2@test.com' },
+                    { name: 'CountUser3', email: 'count3@test.com' },
+                ]);
+
+                const count = await UserModel.find({}).countDocuments().cacheQuery();
+                expect(count).toBe(3);
+            });
+
+            it('should work with lean queries', async () => {
+                const user = await UserModel.create({ name: 'LeanUser', email: 'lean@test.com' });
+
+                const result = await UserModel.findOne({ _id: user._id }).lean().cacheQuery();
+                expect(result).toBeDefined();
+                expect(result!.name).toBe('LeanUser');
+                // Lean results should be plain objects (no mongoose document methods)
+                expect(typeof (result as any).toObject).not.toBe('function');
+            });
+
+            it('should accept custom TTL param', async () => {
+                const user = await UserModel.create({ name: 'TTLUser', email: 'ttl@test.com' });
+
+                const result = await UserModel.findOne({ _id: user._id }).cacheQuery({ ttl: 120 });
+                expect(result).toBeDefined();
+                expect(result!.name).toBe('TTLUser');
+
+                // Verify it is cached
+                const isCachedResult = await UserModel.findOne({ _id: user._id }).isCached();
+                expect(isCachedResult).toBe(true);
+            });
+
+            it('should accept custom cacheKey param', async () => {
+                const user = await UserModel.create({ name: 'CustomKeyUser', email: 'customkey@test.com' });
+                const customKey = 'my-custom-cache-key';
+
+                const result = await UserModel.findOne({ _id: user._id }).cacheQuery({ cacheKey: customKey });
+                expect(result).toBeDefined();
+                expect(result!.name).toBe('CustomKeyUser');
+
+                // Verify it is cached with the custom key
+                const isCachedResult = await UserModel.findOne({ _id: user._id }).isCached({ cacheKey: customKey });
+                expect(isCachedResult).toBe(true);
+            });
+        });
+
+        describe('when caching is disabled', () => {
+            it('should fall through to regular exec()', async () => {
+                const user = await UserModel.create({ name: 'DisabledUser', email: 'disabled@test.com' });
+
+                const isCachingEnabledSpy = jest.spyOn(commonUtils, 'isCachingEnabled').mockReturnValue(false);
+
+                const result = await UserModel.findOne({ _id: user._id }).cacheQuery();
+                expect(result).toBeDefined();
+                expect(result!.name).toBe('DisabledUser');
+
+                // Should NOT be cached because caching was disabled
+                isCachingEnabledSpy.mockRestore();
+                const isCachedResult = await UserModel.findOne({ _id: user._id }).isCached();
+                expect(isCachedResult).toBe(false);
+            });
+        });
+    });
+
+    describe('isCached()', () => {
+        it('should return false when query result is not cached', async () => {
+            const user = await UserModel.create({ name: 'NotCachedUser', email: 'notcached@test.com' });
+
+            const isCachedResult = await UserModel.findOne({ _id: user._id }).isCached();
+            expect(isCachedResult).toBe(false);
+        });
+
+        it('should return true after cacheQuery() has been called', async () => {
+            const user = await UserModel.create({ name: 'CachedUser', email: 'cached@test.com' });
+
+            // Cache the query
+            await UserModel.findOne({ _id: user._id }).cacheQuery();
+
+            // Now it should be cached
+            const isCachedResult = await UserModel.findOne({ _id: user._id }).isCached();
+            expect(isCachedResult).toBe(true);
+        });
+    });
+
+    describe('cachePopulate()', () => {
+        it('should normalize a single string field to [{path: field}]', () => {
+            const query = UserModel.findOne({}).cachePopulate('field1');
+            expect(query._mongooseOptions.speedGoosePopulate).toEqual([{ path: 'field1' }]);
+        });
+
+        it('should normalize a space-separated string to multiple populate options', () => {
+            const query = UserModel.findOne({}).cachePopulate('field1 field2');
+            expect(query._mongooseOptions.speedGoosePopulate).toEqual([
+                { path: 'field1' },
+                { path: 'field2' },
+            ]);
+        });
+
+        it('should wrap a single object in an array', () => {
+            const query = UserModel.findOne({}).cachePopulate({ path: 'x' });
+            expect(query._mongooseOptions.speedGoosePopulate).toEqual([{ path: 'x' }]);
+        });
+
+        it('should pass an array of options as-is', () => {
+            const opts = [{ path: 'x' }, { path: 'y' }];
+            const query = UserModel.findOne({}).cachePopulate(opts);
+            expect(query._mongooseOptions.speedGoosePopulate).toEqual([{ path: 'x' }, { path: 'y' }]);
+        });
+
+        it('should return this for chaining', () => {
+            const query = UserModel.findOne({});
+            const returned = query.cachePopulate('field1');
+            expect(returned).toBe(query);
+        });
+
+        it('should store options in _mongooseOptions.speedGoosePopulate', () => {
+            const query = UserModel.findOne({}).cachePopulate('parent');
+            expect(query._mongooseOptions.speedGoosePopulate).toBeDefined();
+            expect(Array.isArray(query._mongooseOptions.speedGoosePopulate)).toBe(true);
+        });
+
+        it('should accumulate options across multiple cachePopulate() calls', () => {
+            const query = UserModel.findOne({})
+                .cachePopulate('field1')
+                .cachePopulate('field2');
+
+            expect(query._mongooseOptions.speedGoosePopulate).toEqual([
+                { path: 'field1' },
+                { path: 'field2' },
+            ]);
+        });
+
+        it('should handle empty string by producing empty array', () => {
+            const query = UserModel.findOne({}).cachePopulate('');
+            expect(query._mongooseOptions.speedGoosePopulate).toEqual([]);
+        });
+    });
+
+    describe('execQueryWithCache flow', () => {
+        it('should call refreshTTLTimeIfNeeded on cache hit', async () => {
+            const refreshSpy = jest.spyOn(cacheClientUtils, 'refreshTTLTimeIfNeeded');
+            const user = await UserModel.create({ name: 'RefreshTTLUser', email: 'refresh@test.com' });
+
+            // First call populates cache
+            await UserModel.findOne({ _id: user._id }).cacheQuery();
+            refreshSpy.mockClear();
+
+            // Second call should be a cache hit and call refreshTTLTimeIfNeeded
+            await UserModel.findOne({ _id: user._id }).cacheQuery();
+            expect(refreshSpy).toHaveBeenCalled();
+
+            refreshSpy.mockRestore();
+        });
+
+        it('should call setKeyInResultsCaches on cache miss', async () => {
+            const setKeySpy = jest.spyOn(cacheClientUtils, 'setKeyInResultsCaches');
+            const user = await UserModel.create({ name: 'SetKeyUser', email: 'setkey@test.com' });
+
+            // First call is a cache miss
+            await UserModel.findOne({ _id: user._id }).cacheQuery();
+            expect(setKeySpy).toHaveBeenCalled();
+
+            setKeySpy.mockRestore();
+        });
+
+        it('should not call setKeyInResultsCaches on cache hit', async () => {
+            const user = await UserModel.create({ name: 'NoSetKeyUser', email: 'nosetkey@test.com' });
+
+            // First call populates cache
+            await UserModel.findOne({ _id: user._id }).cacheQuery();
+
+            const setKeySpy = jest.spyOn(cacheClientUtils, 'setKeyInResultsCaches');
+
+            // Second call is a cache hit, should NOT call setKeyInResultsCaches
+            await UserModel.findOne({ _id: user._id }).cacheQuery();
+            expect(setKeySpy).not.toHaveBeenCalled();
+
+            setKeySpy.mockRestore();
+        });
+
+        it('should return raw result for lean queries (no hydration)', async () => {
+            const user = await UserModel.create({ name: 'LeanNoHydrate', email: 'leannohydrate@test.com' });
+
+            const result = await UserModel.findOne({ _id: user._id }).lean().cacheQuery();
+            expect(result).toBeDefined();
+            expect(result!.name).toBe('LeanNoHydrate');
+            // Lean result is a plain object
+            expect(typeof (result as any).save).not.toBe('function');
+        });
+
+        it('should return raw result for count queries (no hydration)', async () => {
+            await UserModel.create([
+                { name: 'CountA', email: 'counta@test.com' },
+                { name: 'CountB', email: 'countb@test.com' },
+            ]);
+
+            const count = await UserModel.find({}).countDocuments().cacheQuery();
+            expect(count).toBe(2);
+
+            // Second call from cache
+            const cachedCount = await UserModel.find({}).countDocuments().cacheQuery();
+            expect(cachedCount).toBe(2);
+        });
+
+        it('should return raw result for distinct queries (no hydration)', async () => {
+            await UserModel.create([
+                { name: 'Alice', email: 'alice@test.com' },
+                { name: 'Bob', email: 'bob@test.com' },
+                { name: 'Alice', email: 'alice2@test.com' },
+            ]);
+
+            const result = await UserModel.distinct('name').cacheQuery();
+            expect(result).toBeDefined();
+            expect(Array.isArray(result)).toBe(true);
+            expect((result as string[]).sort()).toEqual(['Alice', 'Bob']);
+        });
+    });
+});

--- a/test/integration/realWorldApp.test.ts
+++ b/test/integration/realWorldApp.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Real-world integration test for speedgoose.
+ *
+ * This test simulates a realistic application that uses speedgoose for
+ * mongoose query caching with the IN_MEMORY strategy. It exercises:
+ *   - Initialization of the cache layer
+ *   - Basic CRUD with cacheQuery()
+ *   - Cache hit verification via isCached()
+ *   - Auto-invalidation on save / delete
+ *   - Aggregate caching via cachePipeline()
+ *   - Cross-model cache isolation
+ *   - Cached population via cachePopulate()
+ *   - Concurrent cached operations
+ *   - Clean shutdown
+ */
+
+import mongoose, { Schema, Model, Document } from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { SpeedGooseCacheAutoCleaner } from '../../index';
+import { clearAllCaches } from '../../src/utils/cacheUtils';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface IUser extends Document {
+    name: string;
+    email: string;
+    age: number;
+    posts?: IPost[] | mongoose.Types.ObjectId[];
+}
+
+interface IPost extends Document {
+    title: string;
+    body: string;
+    author: mongoose.Types.ObjectId | IUser;
+    comments?: IComment[] | mongoose.Types.ObjectId[];
+}
+
+interface IComment extends Document {
+    text: string;
+    post: mongoose.Types.ObjectId | IPost;
+    author: mongoose.Types.ObjectId | IUser;
+}
+
+// ---------------------------------------------------------------------------
+// Models (registered once, reused across tests)
+// ---------------------------------------------------------------------------
+
+let UserModel: Model<IUser>;
+let PostModel: Model<IPost>;
+let CommentModel: Model<IComment>;
+
+// We need a dedicated mongoose connection for this suite because the global
+// setupTestEnv.ts already connects the default mongoose instance. Instead of
+// fighting that, we piggy-back on the same mongoose instance but ensure we have
+// a real MongoDB underneath via mongodb-memory-server (already set up by the
+// global test infra through testUtils.setupTestDB).
+
+let mongoServer: MongoMemoryServer;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const registerModels = () => {
+    // User schema
+    const userSchema = new Schema<IUser>({
+        name: { type: String, required: true },
+        email: { type: String, required: true },
+        age: { type: Number, default: 25 },
+        posts: [{ type: Schema.Types.ObjectId, ref: 'IntegrationPost' }],
+    });
+    userSchema.plugin(SpeedGooseCacheAutoCleaner);
+
+    // Post schema
+    const postSchema = new Schema<IPost>({
+        title: { type: String, required: true },
+        body: { type: String, default: '' },
+        author: { type: Schema.Types.ObjectId, ref: 'IntegrationUser' },
+        comments: [{ type: Schema.Types.ObjectId, ref: 'IntegrationComment' }],
+    });
+    postSchema.plugin(SpeedGooseCacheAutoCleaner);
+
+    // Comment schema
+    const commentSchema = new Schema<IComment>({
+        text: { type: String, required: true },
+        post: { type: Schema.Types.ObjectId, ref: 'IntegrationPost' },
+        author: { type: Schema.Types.ObjectId, ref: 'IntegrationUser' },
+    });
+    commentSchema.plugin(SpeedGooseCacheAutoCleaner);
+
+    UserModel = mongoose.models['IntegrationUser'] ?? mongoose.model<IUser>('IntegrationUser', userSchema);
+    PostModel = mongoose.models['IntegrationPost'] ?? mongoose.model<IPost>('IntegrationPost', postSchema);
+    CommentModel = mongoose.models['IntegrationComment'] ?? mongoose.model<IComment>('IntegrationComment', commentSchema);
+};
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('Real-world integration test', () => {
+    jest.setTimeout(120_000);
+
+    beforeAll(async () => {
+        mongoServer = await MongoMemoryServer.create();
+        const uri = mongoServer.getUri();
+
+        if (mongoose.connection.readyState !== 0) {
+            await mongoose.disconnect();
+        }
+        await mongoose.connect(uri);
+
+        registerModels();
+    }, 60_000);
+
+    afterAll(async () => {
+        // Drop the test database and close the connection
+        if (mongoose.connection.db) {
+            await mongoose.connection.db.dropDatabase();
+        }
+        if (mongoServer) {
+            await mongoServer.stop();
+        }
+    }, 30_000);
+
+    beforeEach(async () => {
+        // The global setupTestEnv.ts already calls Container.reset() and
+        // applySpeedGooseCacheLayer() in its own beforeEach.  We just need
+        // to clean our model data and caches.
+        await Promise.all([
+            UserModel.deleteMany({}),
+            PostModel.deleteMany({}),
+            CommentModel.deleteMany({}),
+        ]);
+        await clearAllCaches();
+    });
+
+    // -----------------------------------------------------------------------
+    // 1. App initialisation
+    // -----------------------------------------------------------------------
+    it('should apply the speedgoose cache layer without errors', async () => {
+        // The global beforeEach already applies the cache layer.  Verify that
+        // the extended methods exist on Query and Aggregate prototypes.
+        expect(typeof mongoose.Query.prototype.cacheQuery).toBe('function');
+        expect(typeof mongoose.Query.prototype.isCached).toBe('function');
+        expect(typeof mongoose.Query.prototype.cachePopulate).toBe('function');
+        expect(typeof mongoose.Aggregate.prototype.cachePipeline).toBe('function');
+        expect(typeof mongoose.Aggregate.prototype.isCached).toBe('function');
+    }, 30_000);
+
+    // -----------------------------------------------------------------------
+    // 2. Basic CRUD with caching
+    // -----------------------------------------------------------------------
+    it('should create documents and return cached results via cacheQuery', async () => {
+        const alice = await UserModel.create({ name: 'Alice', email: 'alice@example.com', age: 30 });
+
+        // First read (populates cache)
+        const result1 = await UserModel.findById(alice._id).cacheQuery();
+        expect(result1).toBeDefined();
+        expect(result1!.name).toBe('Alice');
+        expect(result1!.email).toBe('alice@example.com');
+
+        // Second read (should come from cache) — we verify by confirming that
+        // the returned document is identical to the first.
+        const result2 = await UserModel.findById(alice._id).cacheQuery();
+        expect(result2).toBeDefined();
+        expect(result2!.name).toBe('Alice');
+        expect(JSON.stringify(result2)).toEqual(JSON.stringify(result1));
+    }, 30_000);
+
+    // -----------------------------------------------------------------------
+    // 3. Cache hit verification
+    // -----------------------------------------------------------------------
+    it('should report a cache hit via isCached after the first cacheQuery call', async () => {
+        const bob = await UserModel.create({ name: 'Bob', email: 'bob@example.com', age: 28 });
+
+        const query = UserModel.findById(bob._id);
+
+        // Before any cached call, query should not be cached
+        const cachedBefore = await UserModel.findById(bob._id).isCached();
+        expect(cachedBefore).toBe(false);
+
+        // Populate cache
+        await UserModel.findById(bob._id).cacheQuery();
+
+        // After cached call, the same query pattern should now be cached
+        const cachedAfter = await UserModel.findById(bob._id).isCached();
+        expect(cachedAfter).toBe(true);
+    }, 30_000);
+
+    // -----------------------------------------------------------------------
+    // 4. Cache invalidation on save (update)
+    // -----------------------------------------------------------------------
+    it('should clear cache when a document is updated (auto-cleaner)', async () => {
+        const carol = await UserModel.create({ name: 'Carol', email: 'carol@example.com', age: 35 });
+
+        // Populate cache
+        const result1 = await UserModel.findById(carol._id).cacheQuery();
+        expect(result1!.name).toBe('Carol');
+
+        // Update the document via updateOne (triggers SpeedGooseCacheAutoCleaner)
+        await UserModel.updateOne({ _id: carol._id }, { name: 'Carol Updated' });
+
+        // The cache should have been invalidated; fresh data expected
+        const result2 = await UserModel.findById(carol._id).cacheQuery();
+        expect(result2).toBeDefined();
+        expect(result2!.name).toBe('Carol Updated');
+    }, 30_000);
+
+    // -----------------------------------------------------------------------
+    // 5. Cache invalidation on delete
+    // -----------------------------------------------------------------------
+    it('should clear cache when a document is deleted', async () => {
+        const dave = await UserModel.create({ name: 'Dave', email: 'dave@example.com', age: 40 });
+
+        // Populate cache
+        const result1 = await UserModel.findOne({ email: 'dave@example.com' }).cacheQuery();
+        expect(result1).toBeDefined();
+        expect(result1!.name).toBe('Dave');
+
+        // Delete the document
+        await UserModel.deleteOne({ _id: dave._id });
+
+        // Cache should be invalidated; query should return null now
+        const result2 = await UserModel.findOne({ email: 'dave@example.com' }).cacheQuery();
+        expect(result2).toBeNull();
+    }, 30_000);
+
+    // -----------------------------------------------------------------------
+    // 6. Aggregate caching
+    // -----------------------------------------------------------------------
+    it('should cache aggregate results via cachePipeline', async () => {
+        await UserModel.create([
+            { name: 'Eve', email: 'eve@example.com', age: 20 },
+            { name: 'Frank', email: 'frank@example.com', age: 30 },
+            { name: 'Grace', email: 'grace@example.com', age: 30 },
+        ]);
+
+        const pipeline = [
+            { $group: { _id: '$age', count: { $sum: 1 } } },
+            { $sort: { _id: 1 } },
+        ];
+
+        // First run populates cache
+        const agg1 = await UserModel.aggregate(pipeline).cachePipeline();
+        expect(agg1).toBeDefined();
+        expect(agg1.length).toBe(2);
+        expect(agg1).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ _id: 20, count: 1 }),
+                expect.objectContaining({ _id: 30, count: 2 }),
+            ]),
+        );
+
+        // Second run should return cached results
+        const agg2 = await UserModel.aggregate(pipeline).cachePipeline();
+        expect(JSON.stringify(agg2)).toEqual(JSON.stringify(agg1));
+    }, 30_000);
+
+    // -----------------------------------------------------------------------
+    // 7. Aggregate cache invalidation
+    // -----------------------------------------------------------------------
+    it('should invalidate aggregate cache when underlying data changes', async () => {
+        await UserModel.create([
+            { name: 'Heidi', email: 'heidi@example.com', age: 25 },
+            { name: 'Ivan', email: 'ivan@example.com', age: 25 },
+        ]);
+
+        const pipeline = [
+            { $match: { age: 25 } },
+            { $count: 'total' },
+        ];
+
+        // Populate cache
+        const agg1 = await UserModel.aggregate(pipeline).cachePipeline();
+        expect(agg1).toEqual([{ total: 2 }]);
+
+        // Mutate data
+        await UserModel.create({ name: 'Judy', email: 'judy@example.com', age: 25 });
+
+        // After mutation the cache for this model should be invalidated
+        const agg2 = await UserModel.aggregate(pipeline).cachePipeline();
+        expect(agg2).toEqual([{ total: 3 }]);
+    }, 30_000);
+
+    // -----------------------------------------------------------------------
+    // 8. Multiple models — cache isolation
+    // -----------------------------------------------------------------------
+    it('should only clear cache for the mutated model, not others', async () => {
+        const user = await UserModel.create({ name: 'Karl', email: 'karl@example.com', age: 29 });
+        const post = await PostModel.create({ title: 'My Post', body: 'Hello', author: user._id });
+
+        // Cache queries for both models
+        const cachedUser = await UserModel.findById(user._id).cacheQuery();
+        const cachedPost = await PostModel.findById(post._id).cacheQuery();
+
+        expect(cachedUser!.name).toBe('Karl');
+        expect(cachedPost!.title).toBe('My Post');
+
+        // Verify both are cached
+        const userCached = await UserModel.findById(user._id).isCached();
+        const postCached = await PostModel.findById(post._id).isCached();
+        expect(userCached).toBe(true);
+        expect(postCached).toBe(true);
+
+        // Mutate user only
+        await UserModel.updateOne({ _id: user._id }, { name: 'Karl Updated' });
+
+        // Post cache should still be intact
+        const postStillCached = await PostModel.findById(post._id).isCached();
+        expect(postStillCached).toBe(true);
+
+        // User cache should be invalidated and return fresh data
+        const freshUser = await UserModel.findById(user._id).cacheQuery();
+        expect(freshUser!.name).toBe('Karl Updated');
+    }, 30_000);
+
+    // -----------------------------------------------------------------------
+    // 9. Cached population
+    // -----------------------------------------------------------------------
+    it('should correctly populate and cache related documents', async () => {
+        const author = await UserModel.create({ name: 'Liam', email: 'liam@example.com', age: 32 });
+        const post = await PostModel.create({ title: 'Cached Post', body: 'Content', author: author._id });
+
+        // First query with cachePopulate
+        const result1 = await PostModel.findById(post._id)
+            .cachePopulate({ path: 'author' })
+            .exec();
+
+        expect(result1).toBeDefined();
+        expect(result1!.author).toBeDefined();
+        expect((result1!.author as any).name).toBe('Liam');
+
+        // Second query should serve population from cache.
+        // findById uses findOne for the main query (which is expected to hit the DB),
+        // but the population sub-query (which uses find) should be served from cache.
+        const collectionFindSpy = jest.spyOn(mongoose.Collection.prototype, 'find');
+        const result2 = await PostModel.findById(post._id)
+            .cachePopulate({ path: 'author' })
+            .exec();
+
+        expect(result2).toBeDefined();
+        expect((result2!.author as any).name).toBe('Liam');
+        expect(collectionFindSpy).not.toHaveBeenCalled();
+        collectionFindSpy.mockRestore();
+    }, 30_000);
+
+    // -----------------------------------------------------------------------
+    // 10. Concurrent operations
+    // -----------------------------------------------------------------------
+    it('should handle multiple simultaneous cached queries correctly', async () => {
+        const users = await UserModel.create([
+            { name: 'User1', email: 'u1@example.com', age: 21 },
+            { name: 'User2', email: 'u2@example.com', age: 22 },
+            { name: 'User3', email: 'u3@example.com', age: 23 },
+            { name: 'User4', email: 'u4@example.com', age: 24 },
+            { name: 'User5', email: 'u5@example.com', age: 25 },
+        ]);
+
+        // Run all cached queries concurrently
+        const results = await Promise.all(
+            users.map(u => UserModel.findById(u._id).cacheQuery()),
+        );
+
+        expect(results).toHaveLength(5);
+        results.forEach((result, index) => {
+            expect(result).toBeDefined();
+            expect(result!.name).toBe(`User${index + 1}`);
+        });
+
+        // Run a second wave — should all hit cache
+        const cachedResults = await Promise.all(
+            users.map(u => UserModel.findById(u._id).cacheQuery()),
+        );
+        cachedResults.forEach((result, index) => {
+            expect(result).toBeDefined();
+            expect(result!.name).toBe(`User${index + 1}`);
+        });
+    }, 30_000);
+
+    // -----------------------------------------------------------------------
+    // 11. Clean shutdown
+    // -----------------------------------------------------------------------
+    it('should shutdown the mongoose connection cleanly', async () => {
+        // This test simply verifies that the connection is still healthy after
+        // all the prior tests.  The actual teardown is handled in afterAll.
+        expect(mongoose.connection.readyState).toBe(1); // 1 = connected
+        // Perform one last query to confirm the connection is still usable
+        const count = await UserModel.countDocuments();
+        expect(typeof count).toBe('number');
+    }, 30_000);
+});

--- a/test/mongooseModelEvents.test.ts
+++ b/test/mongooseModelEvents.test.ts
@@ -1,0 +1,345 @@
+import mongoose from 'mongoose';
+import { ObjectId } from 'mongodb';
+import { MongooseDocumentEvents, CacheNamespaces } from '../src/types/types';
+import * as cacheClientUtils from '../src/utils/cacheClientUtils';
+import * as commonUtils from '../src/utils/commonUtils';
+import * as debugUtils from '../src/utils/debugUtils';
+import { registerListenerForInternalEvents } from '../src/mongooseModelEvents';
+import { getMongooseTestModel, clearTestEventListeners } from './testUtils';
+import { TEST_MODEL_NAME } from './constants';
+
+const mockedClearCacheForRecordId = jest.spyOn(cacheClientUtils, 'clearCacheForRecordId');
+const mockedGetCacheStrategyInstance = jest.spyOn(commonUtils, 'getCacheStrategyInstance');
+const mockedGetDebugger = jest.spyOn(debugUtils, 'getDebugger');
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+afterEach(() => {
+    clearTestEventListeners();
+});
+
+describe('registerListenerForInternalEvents', () => {
+    it('should register listeners on all models for both event types', () => {
+        const testModel = getMongooseTestModel();
+        const onSpy = jest.spyOn(testModel, 'on');
+
+        registerListenerForInternalEvents(mongoose);
+
+        const registeredEvents = onSpy.mock.calls.map(call => call[0]);
+        expect(registeredEvents).toContain(MongooseDocumentEvents.SINGLE_DOCUMENT_CHANGED);
+        expect(registeredEvents).toContain(MongooseDocumentEvents.MANY_DOCUMENTS_CHANGED);
+
+        onSpy.mockRestore();
+    });
+
+    it('should handle mongoose with no models gracefully', () => {
+        const emptyMongoose = { models: {} } as unknown as mongoose.Mongoose;
+        expect(() => registerListenerForInternalEvents(emptyMongoose)).not.toThrow();
+    });
+
+    it('should handle null models gracefully', () => {
+        const nullMongoose = { models: null } as unknown as mongoose.Mongoose;
+        expect(() => registerListenerForInternalEvents(nullMongoose)).not.toThrow();
+    });
+});
+
+describe('SINGLE_DOCUMENT_CHANGED event', () => {
+    it('should clear cache for the record ID when emitted', async () => {
+        const testModel = getMongooseTestModel();
+        const recordId = new ObjectId().toString();
+
+        const clearResultsCacheWithSetSpy = jest.fn().mockResolvedValue(undefined);
+        mockedGetCacheStrategyInstance.mockReturnValue({
+            clearResultsCacheWithSet: clearResultsCacheWithSetSpy,
+        } as any);
+
+        mockedClearCacheForRecordId.mockResolvedValue(undefined);
+
+        testModel.emit(MongooseDocumentEvents.SINGLE_DOCUMENT_CHANGED, {
+            record: { _id: recordId },
+            modelName: TEST_MODEL_NAME,
+            wasNew: false,
+            wasDeleted: false,
+        });
+
+        // Allow async event handlers to complete
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        expect(mockedClearCacheForRecordId).toHaveBeenCalledWith(recordId);
+    });
+
+    it('should clear model cache when wasNew is true', async () => {
+        const testModel = getMongooseTestModel();
+        const recordId = new ObjectId().toString();
+
+        const clearResultsCacheWithSetSpy = jest.fn().mockResolvedValue(undefined);
+        mockedGetCacheStrategyInstance.mockReturnValue({
+            clearResultsCacheWithSet: clearResultsCacheWithSetSpy,
+        } as any);
+
+        mockedClearCacheForRecordId.mockResolvedValue(undefined);
+
+        testModel.emit(MongooseDocumentEvents.SINGLE_DOCUMENT_CHANGED, {
+            record: { _id: recordId },
+            modelName: TEST_MODEL_NAME,
+            wasNew: true,
+            wasDeleted: false,
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        expect(mockedClearCacheForRecordId).toHaveBeenCalledWith(recordId);
+        expect(clearResultsCacheWithSetSpy).toHaveBeenCalledWith(`${TEST_MODEL_NAME}_`);
+    });
+
+    it('should clear model cache when wasDeleted is true', async () => {
+        const testModel = getMongooseTestModel();
+        const recordId = new ObjectId().toString();
+
+        const clearResultsCacheWithSetSpy = jest.fn().mockResolvedValue(undefined);
+        mockedGetCacheStrategyInstance.mockReturnValue({
+            clearResultsCacheWithSet: clearResultsCacheWithSetSpy,
+        } as any);
+
+        mockedClearCacheForRecordId.mockResolvedValue(undefined);
+
+        testModel.emit(MongooseDocumentEvents.SINGLE_DOCUMENT_CHANGED, {
+            record: { _id: recordId },
+            modelName: TEST_MODEL_NAME,
+            wasNew: false,
+            wasDeleted: true,
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        expect(mockedClearCacheForRecordId).toHaveBeenCalledWith(recordId);
+        expect(clearResultsCacheWithSetSpy).toHaveBeenCalledWith(`${TEST_MODEL_NAME}_`);
+    });
+
+    it('should NOT clear model cache for simple updates (wasNew=false, wasDeleted=false)', async () => {
+        const testModel = getMongooseTestModel();
+        const recordId = new ObjectId().toString();
+
+        const clearResultsCacheWithSetSpy = jest.fn().mockResolvedValue(undefined);
+        mockedGetCacheStrategyInstance.mockReturnValue({
+            clearResultsCacheWithSet: clearResultsCacheWithSetSpy,
+        } as any);
+
+        mockedClearCacheForRecordId.mockResolvedValue(undefined);
+
+        testModel.emit(MongooseDocumentEvents.SINGLE_DOCUMENT_CHANGED, {
+            record: { _id: recordId },
+            modelName: TEST_MODEL_NAME,
+            wasNew: false,
+            wasDeleted: false,
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        expect(mockedClearCacheForRecordId).toHaveBeenCalledWith(recordId);
+        // clearResultsCacheWithSet should NOT have been called for model cache
+        // (it may be called inside clearCacheForRecordId, but we mocked that)
+        expect(clearResultsCacheWithSetSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe('MANY_DOCUMENTS_CHANGED event', () => {
+    it('should clear cache for each record in the batch', async () => {
+        const testModel = getMongooseTestModel();
+        const recordId1 = new ObjectId().toString();
+        const recordId2 = new ObjectId().toString();
+        const recordId3 = new ObjectId().toString();
+
+        const clearResultsCacheWithSetSpy = jest.fn().mockResolvedValue(undefined);
+        mockedGetCacheStrategyInstance.mockReturnValue({
+            clearResultsCacheWithSet: clearResultsCacheWithSetSpy,
+        } as any);
+
+        mockedClearCacheForRecordId.mockResolvedValue(undefined);
+
+        testModel.emit(MongooseDocumentEvents.MANY_DOCUMENTS_CHANGED, {
+            records: [{ _id: recordId1 }, { _id: recordId2 }, { _id: recordId3 }],
+            modelName: TEST_MODEL_NAME,
+            wasDeleted: false,
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        expect(mockedClearCacheForRecordId).toHaveBeenCalledTimes(3);
+        expect(mockedClearCacheForRecordId).toHaveBeenCalledWith(recordId1);
+        expect(mockedClearCacheForRecordId).toHaveBeenCalledWith(recordId2);
+        expect(mockedClearCacheForRecordId).toHaveBeenCalledWith(recordId3);
+    });
+
+    it('should clear model cache when wasDeleted is true', async () => {
+        const testModel = getMongooseTestModel();
+        const recordId1 = new ObjectId().toString();
+        const recordId2 = new ObjectId().toString();
+
+        const clearResultsCacheWithSetSpy = jest.fn().mockResolvedValue(undefined);
+        mockedGetCacheStrategyInstance.mockReturnValue({
+            clearResultsCacheWithSet: clearResultsCacheWithSetSpy,
+        } as any);
+
+        mockedClearCacheForRecordId.mockResolvedValue(undefined);
+
+        testModel.emit(MongooseDocumentEvents.MANY_DOCUMENTS_CHANGED, {
+            records: [{ _id: recordId1 }, { _id: recordId2 }],
+            modelName: TEST_MODEL_NAME,
+            wasDeleted: true,
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        expect(mockedClearCacheForRecordId).toHaveBeenCalledTimes(2);
+        // Model cache should be cleared for each record since wasDeleted is true
+        expect(clearResultsCacheWithSetSpy).toHaveBeenCalledWith(`${TEST_MODEL_NAME}_`);
+    });
+
+    it('should process all records in parallel', async () => {
+        const testModel = getMongooseTestModel();
+        const callOrder: string[] = [];
+
+        mockedClearCacheForRecordId.mockImplementation(async (recordId: string) => {
+            callOrder.push(recordId);
+            return undefined;
+        });
+
+        const clearResultsCacheWithSetSpy = jest.fn().mockResolvedValue(undefined);
+        mockedGetCacheStrategyInstance.mockReturnValue({
+            clearResultsCacheWithSet: clearResultsCacheWithSetSpy,
+        } as any);
+
+        const recordId1 = new ObjectId().toString();
+        const recordId2 = new ObjectId().toString();
+
+        testModel.emit(MongooseDocumentEvents.MANY_DOCUMENTS_CHANGED, {
+            records: [{ _id: recordId1 }, { _id: recordId2 }],
+            modelName: TEST_MODEL_NAME,
+            wasDeleted: false,
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        // Both records should have been processed
+        expect(callOrder).toContain(recordId1);
+        expect(callOrder).toContain(recordId2);
+        expect(callOrder).toHaveLength(2);
+    });
+});
+
+describe('prepareDocumentEventContext', () => {
+    it('should set up debugger on context for SINGLE_DOCUMENT_CHANGED', async () => {
+        const testModel = getMongooseTestModel();
+        const recordId = new ObjectId().toString();
+
+        mockedClearCacheForRecordId.mockResolvedValue(undefined);
+        const clearResultsCacheWithSetSpy = jest.fn().mockResolvedValue(undefined);
+        mockedGetCacheStrategyInstance.mockReturnValue({
+            clearResultsCacheWithSet: clearResultsCacheWithSetSpy,
+        } as any);
+
+        testModel.emit(MongooseDocumentEvents.SINGLE_DOCUMENT_CHANGED, {
+            record: { _id: recordId },
+            modelName: TEST_MODEL_NAME,
+            wasNew: false,
+            wasDeleted: false,
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        expect(mockedGetDebugger).toHaveBeenCalledWith(TEST_MODEL_NAME, 'event');
+    });
+
+    it('should set up debugger on context for MANY_DOCUMENTS_CHANGED', async () => {
+        const testModel = getMongooseTestModel();
+        const recordId = new ObjectId().toString();
+
+        mockedClearCacheForRecordId.mockResolvedValue(undefined);
+        const clearResultsCacheWithSetSpy = jest.fn().mockResolvedValue(undefined);
+        mockedGetCacheStrategyInstance.mockReturnValue({
+            clearResultsCacheWithSet: clearResultsCacheWithSetSpy,
+        } as any);
+
+        testModel.emit(MongooseDocumentEvents.MANY_DOCUMENTS_CHANGED, {
+            records: [{ _id: recordId }],
+            modelName: TEST_MODEL_NAME,
+            wasDeleted: false,
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        expect(mockedGetDebugger).toHaveBeenCalledWith(TEST_MODEL_NAME, 'event');
+    });
+});
+
+describe('Integration with caching', () => {
+    beforeEach(() => {
+        // Restore mocks so real cache strategy is used
+        mockedClearCacheForRecordId.mockRestore();
+        mockedGetCacheStrategyInstance.mockRestore();
+    });
+
+    it('should clear cache when SINGLE_DOCUMENT_CHANGED is emitted for a cached query', async () => {
+        const testModel = getMongooseTestModel();
+        const strategy = commonUtils.getCacheStrategyInstance();
+        const cacheKey = 'integration_single_test_key';
+        const recordId = new ObjectId().toString();
+
+        // Manually put something in the cache
+        await strategy.addValueToCache(CacheNamespaces.RESULTS_NAMESPACE, cacheKey, { name: 'cached_result' });
+        await strategy.addValueToManyCachedSets([recordId], cacheKey);
+
+        // Verify it is cached
+        const cachedBefore = await strategy.getValueFromCache(CacheNamespaces.RESULTS_NAMESPACE, cacheKey);
+        expect(cachedBefore).toEqual({ name: 'cached_result' });
+
+        // Emit the event
+        testModel.emit(MongooseDocumentEvents.SINGLE_DOCUMENT_CHANGED, {
+            record: { _id: recordId },
+            modelName: TEST_MODEL_NAME,
+            wasNew: false,
+            wasDeleted: false,
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        // Verify cache was cleared
+        const cachedAfter = await strategy.getValueFromCache(CacheNamespaces.RESULTS_NAMESPACE, cacheKey);
+        expect(cachedAfter).toBeNull();
+    });
+
+    it('should clear cache when MANY_DOCUMENTS_CHANGED is emitted for cached queries', async () => {
+        const testModel = getMongooseTestModel();
+        const strategy = commonUtils.getCacheStrategyInstance();
+        const cacheKey1 = 'integration_many_test_key_1';
+        const cacheKey2 = 'integration_many_test_key_2';
+        const recordId1 = new ObjectId().toString();
+        const recordId2 = new ObjectId().toString();
+
+        // Manually put something in the cache
+        await strategy.addValueToCache(CacheNamespaces.RESULTS_NAMESPACE, cacheKey1, { name: 'cached_result_1' });
+        await strategy.addValueToManyCachedSets([recordId1], cacheKey1);
+        await strategy.addValueToCache(CacheNamespaces.RESULTS_NAMESPACE, cacheKey2, { name: 'cached_result_2' });
+        await strategy.addValueToManyCachedSets([recordId2], cacheKey2);
+
+        // Verify they are cached
+        expect(await strategy.getValueFromCache(CacheNamespaces.RESULTS_NAMESPACE, cacheKey1)).toEqual({ name: 'cached_result_1' });
+        expect(await strategy.getValueFromCache(CacheNamespaces.RESULTS_NAMESPACE, cacheKey2)).toEqual({ name: 'cached_result_2' });
+
+        // Emit the event
+        testModel.emit(MongooseDocumentEvents.MANY_DOCUMENTS_CHANGED, {
+            records: [{ _id: recordId1 }, { _id: recordId2 }],
+            modelName: TEST_MODEL_NAME,
+            wasDeleted: false,
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        // Verify caches were cleared
+        expect(await strategy.getValueFromCache(CacheNamespaces.RESULTS_NAMESPACE, cacheKey1)).toBeNull();
+        expect(await strategy.getValueFromCache(CacheNamespaces.RESULTS_NAMESPACE, cacheKey2)).toBeNull();
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,6 +1478,13 @@
   dependencies:
     "@types/webidl-conversions" "*"
 
+"@types/whatwg-url@^13.0.0":
+  version "13.0.0"
+  resolved "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz"
+  integrity sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==
+  dependencies:
+    "@types/webidl-conversions" "*"
+
 "@types/yargs-parser@*":
   version "21.0.3"
   resolved "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz"
@@ -1949,6 +1956,11 @@ bson@^6.10.4:
   resolved "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz"
   integrity sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==
 
+bson@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz"
+  integrity sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==
+
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
@@ -2387,7 +2399,7 @@ date-fns@^1.27.2:
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.3, debug@4, debug@4.x:
+debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.3, debug@4:
   version "4.4.3"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -4154,10 +4166,10 @@ just-diff@^6.0.0:
   resolved "https://registry.npmjs.org/just-diff/-/just-diff-6.0.2.tgz"
   integrity sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==
 
-kareem@2.6.3:
-  version "2.6.3"
-  resolved "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz"
-  integrity sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==
+kareem@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/kareem/-/kareem-3.2.0.tgz"
+  integrity sha512-VS8MWZz/cT+SqBCpVfNN4zoVz5VskR3N4+sTmUXme55e9avQHntpwpNq0yjnosISXqwJ3AQVjlbI4Dyzv//JtA==
 
 keyv@^4.5.4:
   version "4.5.4"
@@ -4785,6 +4797,14 @@ mongodb-connection-string-url@^3.0.2:
     "@types/whatwg-url" "^11.0.2"
     whatwg-url "^14.1.0 || ^13.0.0"
 
+mongodb-connection-string-url@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz"
+  integrity sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==
+  dependencies:
+    "@types/whatwg-url" "^13.0.0"
+    whatwg-url "^14.1.0"
+
 mongodb-memory-server-core@10.4.3:
   version "10.4.3"
   resolved "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-10.4.3.tgz"
@@ -4811,7 +4831,7 @@ mongodb-memory-server@^10.4.3:
     mongodb-memory-server-core "10.4.3"
     tslib "^2.8.1"
 
-mongodb@^6.9.0, mongodb@~6.20.0:
+mongodb@^6.9.0:
   version "6.20.0"
   resolved "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz"
   integrity sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==
@@ -4820,16 +4840,24 @@ mongodb@^6.9.0, mongodb@~6.20.0:
     bson "^6.10.4"
     mongodb-connection-string-url "^3.0.2"
 
-mongoose@^8.21.1:
-  version "8.21.1"
-  resolved "https://registry.npmjs.org/mongoose/-/mongoose-8.21.1.tgz"
-  integrity sha512-1LhrVeHwiyAGxwSaYSq2uf32izQD+qoM2c8wq63W8MIsJBxKQDBnMkhJct55m0qqCsm2Maq8aPpIIfOHSYAqxg==
+mongodb@~7.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/mongodb/-/mongodb-7.0.0.tgz"
+  integrity sha512-vG/A5cQrvGGvZm2mTnCSz1LUcbOPl83hfB6bxULKQ8oFZauyox/2xbZOoGNl+64m8VBrETkdGCDBdOsCr3F3jg==
   dependencies:
-    bson "^6.10.4"
-    kareem "2.6.3"
-    mongodb "~6.20.0"
+    "@mongodb-js/saslprep" "^1.3.0"
+    bson "^7.0.0"
+    mongodb-connection-string-url "^7.0.0"
+
+mongoose@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.npmjs.org/mongoose/-/mongoose-9.2.0.tgz"
+  integrity sha512-lc1uFbtZHp1FqP8UCzRs9JZLhbBEmDt1l6B2MYmbD07Lp99yppQUwg2yPPyB3NO18EE5nQAoGCRiTf5v6vuJBQ==
+  dependencies:
+    kareem "3.2.0"
+    mongodb "~7.0"
     mpath "0.9.0"
-    mquery "5.0.0"
+    mquery "6.0.0"
     ms "2.1.3"
     sift "17.1.3"
 
@@ -4838,12 +4866,10 @@ mpath@^0.9.0, mpath@0.9.0:
   resolved "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz"
   integrity sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==
 
-mquery@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz"
-  integrity sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==
-  dependencies:
-    debug "4.x"
+mquery@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/mquery/-/mquery-6.0.0.tgz"
+  integrity sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==
 
 ms@^2.1.2, ms@^2.1.3, ms@2.1.3:
   version "2.1.3"
@@ -6774,7 +6800,7 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
-"whatwg-url@^14.1.0 || ^13.0.0":
+whatwg-url@^14.1.0, "whatwg-url@^14.1.0 || ^13.0.0":
   version "14.2.0"
   resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz"
   integrity sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==


### PR DESCRIPTION
## what's this about

Upgrades mongoose from 8.x to 9.x. Adapted all the internals to the new API, fixed a sneaky pre-existing bug along the way, and added a bunch of tests that were missing.

## what changed

**mongoose 9 migration:**
- removed `next()` from all pre/post middleware hooks — mongoose 9 dropped callback-style hooks entirely
- updated Aggregate type augmentation from 2 generic params to 1 (mongoose 9 simplified this)
- updated Query type augmentation generics to match new signature
- fixed `cachePipeline()` return type — was lying about returning `Aggregate<R[]>`, actually returns `R` (the plain array)
- fixed `cacheQuery()` return type — same idea, returns `ResultType` not `Query<...>`
- added `| null` to cache miss return types for type honesty
- added `engines: { node: ">=20.19.0" }` since mongoose 9 requires it

**bug fix (pre-existing, not from the upgrade):**
- fixed missing spread on `MONGOOSE_UPDATE_ONE_ACTIONS` — `updateOne`, `findOneAndUpdate`, and `findByIdAndUpdate` pre-hooks were silently not being registered because the array was nested instead of spread. cache invalidation for single-doc updates was broken. wild that this slipped through tbh
- switched `||` to `??` in `inMemoryStrategy.getValueFromCache` so cached falsy values like `0` (count queries) aren't treated as cache misses

**new tests (55 tests across 5 files):**
- `test/extendQuery.test.ts` — 25 tests for cacheQuery, isCached, cachePopulate
- `test/extendAggregate.test.ts` — 16 tests for cachePipeline, isCached, edge cases
- `test/mongooseModelEvents.test.ts` — 14 tests for event-based cache invalidation
- `test/integration/realWorldApp.test.ts` — 11 E2E tests (app init, CRUD caching, invalidation, population, concurrent ops)
- `test/benchmark/performance.test.ts` — perf comparison with/without cache

**readme:**
- replaced outdated "mongoose 8.8.0 beta" note with compatibility table
- added performance section with benchmark numbers
- updated roadmap — all test checkboxes now checked

## benchmark results

| operation | uncached | cached | speedup |
|-----------|----------|--------|---------|
| `findOne` | ~1.4 ms | ~0.03 ms | **~50x** |
| `find` (20 results) | ~1.5 ms | ~0.02 ms | **~75x** |
| `aggregate` | ~3.9 ms | ~0.02 ms | **~200x** |
| `populate` | ~4.4 ms | ~0.02 ms | **~230x** |

run `yarn benchmark` to reproduce

## verification

- [x] `tsc --noEmit` — zero errors
- [x] `eslint --quiet` — zero errors  
- [x] `jest` — 275/275 tests passing, 23 suites
- [x] benchmarks complete successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in benchmark script and full performance benchmark suite; new Aggregate isCached API.

* **Improvements**
  * README updated with compatibility matrix, performance details, and benchmarking guidance.
  * Upgraded Mongoose to 9.2.0 and set Node.js minimum to >=20.19.0.
  * Roadmap/Getting Started updated to mark tests done and add new roadmap items.

* **Tests**
  * Extensive unit, integration, and real-world test suites for caching, invalidation, events, and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->