### PR TITLE
fix: auto-add populate paths to inclusive projections in cachePopulate

### DIFF
--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -63,7 +63,7 @@ const ensurePopulatePathsInProjection = (query: Query<any, any>, populateOptions
     const projection = query.projection() as Record<string, any> | null;
     if (!projection || Object.keys(projection).length === 0) return;
 
-    const isInclusive = Object.entries(projection).some(([key, val]) => key !== '_id' && val === 1);
+    const isInclusive = Object.entries(projection).some(([key, val]) => key !== '_id' && (val === 1 || val === true));
     if (!isInclusive) return;
 
     for (const opt of populateOptions) {

--- a/test/features/cachePopulate.test.ts
+++ b/test/features/cachePopulate.test.ts
@@ -787,6 +787,25 @@ describe('cachePopulate', () => {
         expect((populatedParent as any).age).toBeUndefined();
     });
 
+    it('should populate correctly when projection uses boolean true values', async () => {
+        const parent = await UserModel.create({ name: 'Parent', email: 'parent@example.com' });
+        const child = await UserModel.create({
+            name: 'Child',
+            email: 'child@example.com',
+            parent: parent._id,
+        });
+
+        // Projection with boolean true (Mongoose preserves this, doesn't normalize to 1)
+        const result = await UserModel.findOne({ _id: child._id }, { name: true, email: true } as any)
+            .cachePopulate({ path: 'parent' })
+            .exec();
+
+        expect(result).toBeDefined();
+        expect(result!.name).toBe('Child');
+        expect(result!.parent).toBeDefined();
+        expect((result!.parent as unknown as IUser).name).toBe('Parent');
+    });
+
     it('should handle array refs with null entries mixed with valid ids', async () => {
         const parent1 = await UserModel.create({ name: 'Parent1', email: 'p1@example.com' });
         const parent2 = await UserModel.create({ name: 'Parent2', email: 'p2@example.com' });


### PR DESCRIPTION
## Summary

- When using `cachePopulate` with a query that has an inclusive `select`/projection (e.g. `.select('name email')`), the populate path field wasn't being returned by MongoDB → `mpath.get()` returned `undefined` → population was silently skipped
- Added `ensurePopulatePathsInProjection()` in `wrapper.ts` that detects inclusive projections and auto-adds missing populate paths before query execution — same behavior as native Mongoose `.populate()`
- Exclusive projections and queries without `select` are unaffected

## Test plan

- [x] New test: `.select('name email')` + `.cachePopulate({ path: 'parent' })` → parent populated correctly
- [x] New test: `find({}, 'name email')` projection arg + cachePopulate  
- [x] New test: exclusive projection (`-email`) + cachePopulate → works without modification
- [x] New test: array refs with projection excluding the array field
- [x] New test: multiple populate paths both missing from projection
- [x] New test: select + lean + cachePopulate combined
- [x] New test: select on both query and populate options
- [x] All 349 existing tests still pass

Closes #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected query projection handling to ensure fields needed for population are included before executing queries.

* **Tests**
  * Expanded and consolidated test coverage for caching and population scenarios (projections, lean/non-lean, updates/deletes, arrays, cross-model population, and edge cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->