### PR TITLE
fix: register stitched populates in Mongoose bookkeeping

### DIFF
--- a/src/utils/hydrationUtils.ts
+++ b/src/utils/hydrationUtils.ts
@@ -4,7 +4,7 @@ import { CachedDocument, SpeedGooseCacheOperationContext } from '../types/types'
 import { setKeyInHydrationCaches } from './cacheClientUtils';
 import { generateCacheKeyForSingleDocument } from './cacheKeyUtils';
 import { getHydrationCache } from './commonUtils';
-import { getValueFromDocument, isResultWithIds, getMongooseModelByName, setValueOnDocument, isMongooseUnpopulatedField } from './mongooseUtils';
+import { getValueFromDocument, isResultWithIds, getMongooseModelByName, setValueOnDocument, isMongooseUnpopulatedField, markPathPopulated } from './mongooseUtils';
 
 type FieldWithReferenceModel = {
     path: string;
@@ -59,9 +59,11 @@ const deepHydrate = <T>(model: Model<T>, record: CachedDocument<T>): CachedDocum
             if (!Array.isArray(value)) {
                 const hydratedValue = deepHydrate(getMongooseModelByName(field.referenceModelName), value as CachedDocument<T>);
                 setValueOnDocument(field.path, hydratedValue, hydratedRootDocument);
+                markPathPopulated(hydratedRootDocument, field.path, (value as CachedDocument<T>)?._id);
             } else {
                 const hydratedValue = value.map(valueToHydrate => deepHydrate(getMongooseModelByName(field.referenceModelName), valueToHydrate), hydratedRootDocument);
                 setValueOnDocument(field.path, hydratedValue, hydratedRootDocument);
+                markPathPopulated(hydratedRootDocument, field.path, value.map((valueToHydrate: { _id?: CachedDocument<T> }) => valueToHydrate?._id));
             }
         }
     }

--- a/src/utils/mongooseUtils.ts
+++ b/src/utils/mongooseUtils.ts
@@ -39,3 +39,16 @@ export const isMongooseUnpopulatedField = <T>(record: CachedDocument<T>, path: s
 
     return value[0] && isObjectIdOrHexString(value[0]);
 };
+
+type PopulatedPathRegistrar = { populated?: (path: string, val?: unknown) => unknown };
+
+/**
+ * Registers a stitched populate in Mongoose's `$__.populated` bookkeeping so a
+ * cache-hydrated doc depopulates/repopulates like a freshly-populated one.
+ *
+ * @param ids the original reference id(s) that lived at `path` before stitching
+ */
+export const markPathPopulated = <T>(doc: Document<T>, path: string, ids: unknown): void => {
+    const target = doc as PopulatedPathRegistrar;
+    if (typeof target?.populated === 'function' && ids != null) target.populated(path, ids);
+};

--- a/src/utils/populationUtils.ts
+++ b/src/utils/populationUtils.ts
@@ -1,5 +1,5 @@
 import { Document, Model, Query } from 'mongoose';
-import { getMongooseModelByName } from './mongooseUtils';
+import { getMongooseModelByName, markPathPopulated } from './mongooseUtils';
 import { getCacheStrategyInstance } from './commonUtils';
 import { getSetsTtl, getMaxSetCardinality } from './cacheClientUtils';
 import { CacheNamespaces, SpeedGoosePopulateOptions, CachedResult, TtlInheritance } from '../types/types';
@@ -95,6 +95,9 @@ export const stitchAndRelateDocuments = async <T extends Document>(
 
         const hydratedValue = hydratePopulatedData(populatedValue, populatedModel, isLean);
         mpath.set(path, hydratedValue, doc);
+
+        // Keep Mongoose's populate bookkeeping in sync with the stitched value.
+        if (!isLean) markPathPopulated(doc, path, ids);
 
         // Collect parent-child relationships for batch cache update
         const childIds = Array.isArray(ids) ? ids : [ids];

--- a/test/bugs/depopulateAfterCachePopulate.test.ts
+++ b/test/bugs/depopulateAfterCachePopulate.test.ts
@@ -1,0 +1,169 @@
+import mongoose, { Document } from 'mongoose';
+import { applySpeedGooseCacheLayer } from '../../src/wrapper';
+import { SpeedGooseCacheAutoCleaner } from '../../src/plugin/SpeedGooseCacheAutoCleaner';
+import { UserModel, setupTestDB, clearTestCache } from '../testUtils';
+
+/**
+ * Regression tests for the populate-bookkeeping fix (markPathPopulated).
+ * Array-nested refs (`members.user`) fail without the fix — depopulate was a silent
+ * no-op; single refs already work via Mongoose's setter, so those are just coverage.
+ */
+
+interface IClientMember {
+    user: unknown;
+    role?: string;
+}
+
+interface IClient extends Document {
+    name: string;
+    members: IClientMember[];
+    owner?: unknown;
+    populate(path: string): Promise<this>;
+    populated(path: string): unknown;
+    depopulate(path: string): this;
+}
+
+const MemberSchema = new mongoose.Schema({
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    role: String,
+});
+
+const ClientSchema = new mongoose.Schema({
+    name: String,
+    members: [MemberSchema],
+    owner: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+});
+ClientSchema.plugin(SpeedGooseCacheAutoCleaner);
+
+const ClientModel = (mongoose.models.Client as mongoose.Model<IClient>) || mongoose.model<IClient>('Client', ClientSchema);
+
+describe('bug: depopulate after cachePopulate', () => {
+    beforeAll(async () => {
+        await setupTestDB();
+        await applySpeedGooseCacheLayer(mongoose, {});
+    });
+
+    afterAll(async () => {
+        await mongoose.connection.close();
+        await mongoose.disconnect();
+    });
+
+    beforeEach(async () => {
+        await clearTestCache();
+        await UserModel.deleteMany({});
+        await ClientModel.deleteMany({});
+    });
+
+    describe('single ref', () => {
+        it('registers the populate so doc.populated(path) returns the original id', async () => {
+            const owner = await UserModel.create({ name: 'Owner', email: 'owner@example.com' });
+            const created = await ClientModel.create({ name: 'Acme', owner: owner._id });
+
+            const client = (await ClientModel.findById(created._id).cachePopulate({ path: 'owner' }).exec()) as IClient;
+
+            expect(client.owner).toBeInstanceOf(mongoose.Document);
+            expect(client.populated('owner')).toBeDefined();
+            expect(String(client.populated('owner'))).toBe(String(owner._id));
+        });
+
+        it('depopulate restores the ObjectId on a cache-hydrated doc', async () => {
+            const owner = await UserModel.create({ name: 'Owner', email: 'owner@example.com' });
+            const created = await ClientModel.create({ name: 'Acme', owner: owner._id });
+
+            const client = (await ClientModel.findById(created._id).cachePopulate({ path: 'owner' }).exec()) as IClient;
+
+            client.depopulate('owner');
+            expect(client.owner).toBeInstanceOf(mongoose.Types.ObjectId);
+            expect(String(client.owner)).toBe(String(owner._id));
+
+            await client.populate('owner');
+            expect(client.owner).toBeInstanceOf(mongoose.Document);
+            expect((client.owner as { name: string }).name).toBe('Owner');
+        });
+    });
+
+    describe('array-nested ref (members.user)', () => {
+        const createClientWithMembers = async () => {
+            const userA = await UserModel.create({ name: 'Alice', email: 'alice@example.com' });
+            const userB = await UserModel.create({ name: 'Bob', email: 'bob@example.com' });
+            const created = await ClientModel.create({
+                name: 'Acme',
+                members: [
+                    { user: userA._id, role: 'director' },
+                    { user: userB._id, role: 'secretary' },
+                ],
+            });
+            return { userA, userB, created };
+        };
+
+        it('registers the populate on every member sub-document', async () => {
+            const { userA, userB, created } = await createClientWithMembers();
+
+            const client = (await ClientModel.findById(created._id).cachePopulate({ path: 'members.user' }).exec()) as IClient;
+
+            expect(client.members[0].user).toBeInstanceOf(mongoose.Document);
+            expect(client.members[1].user).toBeInstanceOf(mongoose.Document);
+            const member0 = client.members[0] as unknown as { populated(path: string): unknown };
+            const member1 = client.members[1] as unknown as { populated(path: string): unknown };
+            expect(String(member0.populated('user'))).toBe(String(userA._id));
+            expect(String(member1.populated('user'))).toBe(String(userB._id));
+        });
+
+        it('depopulate restores each member id on a cache-hydrated doc (a silent no-op without the fix)', async () => {
+            const { userA, userB, created } = await createClientWithMembers();
+
+            const client = (await ClientModel.findById(created._id).cachePopulate({ path: 'members.user' }).exec()) as IClient;
+
+            client.depopulate('members.user');
+
+            // Without the fix depopulate no-ops, leaving full Documents.
+            expect(client.members[0].user).toBeInstanceOf(mongoose.Types.ObjectId);
+            expect(client.members[1].user).toBeInstanceOf(mongoose.Types.ObjectId);
+            expect(String(client.members[0].user)).toBe(String(userA._id));
+            expect(String(client.members[1].user)).toBe(String(userB._id));
+        });
+
+        it('survives a full depopulate -> populate round-trip with every member.user present', async () => {
+            const { created } = await createClientWithMembers();
+
+            const client = (await ClientModel.findById(created._id).cachePopulate({ path: 'members.user' }).exec()) as IClient;
+
+            client.depopulate('members.user');
+            await client.populate('members.user');
+
+            for (const member of client.members) {
+                expect(member.user).toBeTruthy();
+                expect(member.user).toBeInstanceOf(mongoose.Document);
+            }
+            expect((client.members[0].user as { name: string }).name).toBe('Alice');
+            expect((client.members[1].user as { name: string }).name).toBe('Bob');
+        });
+
+        it('matches a freshly-populated (non-cache) document', async () => {
+            const { created } = await createClientWithMembers();
+
+            const fromDb = (await ClientModel.findById(created._id).populate('members.user').exec()) as IClient;
+            const fromCache = (await ClientModel.findById(created._id).cachePopulate({ path: 'members.user' }).exec()) as IClient;
+
+            expect(Boolean(fromCache.populated('members.user'))).toBe(Boolean(fromDb.populated('members.user')));
+
+            fromDb.depopulate('members.user');
+            fromCache.depopulate('members.user');
+            expect(String(fromCache.members[0].user)).toBe(String(fromDb.members[0].user));
+            expect(String(fromCache.members[1].user)).toBe(String(fromDb.members[1].user));
+        });
+    });
+
+    describe('lean queries', () => {
+        it('does not attempt to register populate state on a lean (plain object) result', async () => {
+            const owner = await UserModel.create({ name: 'Owner', email: 'owner@example.com' });
+            const created = await ClientModel.create({ name: 'Acme', owner: owner._id });
+
+            const client = await ClientModel.findById(created._id).lean().cachePopulate({ path: 'owner' }).exec();
+
+            expect(client).toBeDefined();
+            expect(client!.owner).not.toBeInstanceOf(mongoose.Document);
+            expect((client!.owner as unknown as { name: string }).name).toBe('Owner');
+        });
+    });
+});


### PR DESCRIPTION
### Summary

`cachePopulate` and the hydration path stitch populated refs onto a document with `mpath.set`, which never records the populate in Mongoose's `$__.populated` bookkeeping. So a cache-hydrated document *looks* populated but:

- `doc.populated(path)` returns `undefined`
- `doc.depopulate(path)` silently no-ops on array-nested refs (e.g. `members.user`), leaving the full sub-docs in place

The document therefore can't be depopulated/repopulated the way a `Model.populate()` result can, which breaks consumers that rely on that round-trip.

### Fix

After stitching, register the populate via `doc.populated(path, ids)` so a cache-hydrated document behaves identically to a Mongoose-populated one. (Sub-documents are already marked by their own setters during `mpath.set`, so only the parent path needs registering.) Skipped for lean queries.

### Tests

Adds `test/bugs/depopulateAfterCachePopulate.test.ts` covering single and array-nested refs. The array-nested cases fail without the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kept Mongoose populate bookkeeping in sync during cache-backed hydration and document stitching, ensuring populated paths remain consistent.
  * Fixed `depopulate()` restoring correct values for both single references and nested array references after cached population.
  * Preserved `.lean()` behavior, continuing to return plain objects without populate tracking.
* **Tests**
  * Added regression coverage for cache population/depopulation/repoupulation, nested references, and lean query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->