### PR TITLE
fix: keep populate positions aligned when a cached ref is unresolvable

### DIFF
--- a/src/utils/populationUtils.ts
+++ b/src/utils/populationUtils.ts
@@ -83,6 +83,7 @@ export const stitchAndRelateDocuments = async <T extends Document>(
     docsFromCache: Map<string, CachedResult<unknown>>,
     isLean: boolean,
     parentModelName: string,
+    isDirectArrayPath = false,
 ) => {
     const cacheStrategy = getCacheStrategyInstance();
     const relationships: Array<{ childIdentifier: string; parentIdentifier: string }> = [];
@@ -91,7 +92,10 @@ export const stitchAndRelateDocuments = async <T extends Document>(
         const ids = mpath.get(path, doc);
         if (ids == null) continue;
         const getCacheValue = (id: any) => (id != null ? docsFromCache.get(getDocumentCacheKey(populatedModel.modelName, id.toString(), select)) : undefined);
-        const populatedValue = Array.isArray(ids) ? ids.map(getCacheValue).filter(Boolean) : getCacheValue(ids);
+        // Match native populate: direct ref arrays drop unresolved refs, but paths traversing
+        // sub-document arrays must keep null placeholders — mpath.set assigns positionally, so a
+        // shortened array would stitch the wrong documents onto later elements.
+        const populatedValue = Array.isArray(ids) ? (isDirectArrayPath ? ids.map(getCacheValue).filter(Boolean) : ids.map(id => getCacheValue(id) ?? null)) : (getCacheValue(ids) ?? null);
 
         const hydratedValue = hydratePopulatedData(populatedValue, populatedModel, isLean);
         mpath.set(path, hydratedValue, doc);
@@ -157,7 +161,8 @@ export const handleSinglePopulation = async <T extends Document>(documents: T[],
         newDocs.forEach((value, key) => docsFromCache.set(key, value));
     }
 
-    await stitchAndRelateDocuments(documents, path, populatedModel, select, docsFromCache, lean, query.model.modelName);
+    const isDirectArrayPath = schemaField.instance === 'Array';
+    await stitchAndRelateDocuments(documents, path, populatedModel, select, docsFromCache, lean, query.model.modelName, isDirectArrayPath);
 };
 
 /**

--- a/test/bugs/cachePopulateDanglingRefAlignment.test.ts
+++ b/test/bugs/cachePopulateDanglingRefAlignment.test.ts
@@ -1,0 +1,157 @@
+import mongoose, { Document } from 'mongoose';
+import { applySpeedGooseCacheLayer } from '../../src/wrapper';
+import { SpeedGooseCacheAutoCleaner } from '../../src/plugin/SpeedGooseCacheAutoCleaner';
+import { setupTestDB, clearTestCache } from '../testUtils';
+
+/**
+ * Regression tests for dangling-ref alignment in cachePopulate.
+ * When a populate path traverses an array of sub-documents (`members.child`) and one
+ * ref is unresolvable, the stitched array must keep its positions with a null
+ * placeholder — exactly like native populate. Without the fix the unresolved entry was
+ * filtered out, shifting later docs onto the wrong sub-documents and leaving a trailing
+ * raw ObjectId. Direct ref arrays (`kids`) instead drop unresolved entries, again
+ * matching native populate.
+ */
+
+interface IAlignmentChild extends Document {
+    name: string;
+    ping(): string;
+}
+
+interface IAlignmentMember {
+    child: IAlignmentChild | mongoose.Types.ObjectId | null;
+    role?: string;
+}
+
+interface IAlignmentParent extends Document {
+    title: string;
+    members: IAlignmentMember[];
+    kids: (IAlignmentChild | mongoose.Types.ObjectId)[];
+    favorite?: IAlignmentChild | mongoose.Types.ObjectId | null;
+}
+
+const AlignmentChildSchema = new mongoose.Schema({
+    name: String,
+});
+AlignmentChildSchema.methods.ping = function () {
+    return 'pong';
+};
+AlignmentChildSchema.plugin(SpeedGooseCacheAutoCleaner);
+
+const AlignmentMemberSchema = new mongoose.Schema({
+    child: { type: mongoose.Schema.Types.ObjectId, ref: 'AlignmentChild' },
+    role: String,
+});
+
+const AlignmentParentSchema = new mongoose.Schema({
+    title: String,
+    members: [AlignmentMemberSchema],
+    kids: [{ type: mongoose.Schema.Types.ObjectId, ref: 'AlignmentChild' }],
+    favorite: { type: mongoose.Schema.Types.ObjectId, ref: 'AlignmentChild' },
+});
+AlignmentParentSchema.plugin(SpeedGooseCacheAutoCleaner);
+
+const AlignmentChildModel = (mongoose.models.AlignmentChild as mongoose.Model<IAlignmentChild>) || mongoose.model<IAlignmentChild>('AlignmentChild', AlignmentChildSchema);
+const AlignmentParentModel = (mongoose.models.AlignmentParent as mongoose.Model<IAlignmentParent>) || mongoose.model<IAlignmentParent>('AlignmentParent', AlignmentParentSchema);
+
+describe('bug: cachePopulate dangling-ref alignment', () => {
+    beforeAll(async () => {
+        await setupTestDB();
+        await applySpeedGooseCacheLayer(mongoose, {});
+    });
+
+    afterAll(async () => {
+        await mongoose.connection.close();
+        await mongoose.disconnect();
+    });
+
+    beforeEach(async () => {
+        await clearTestCache();
+        await AlignmentChildModel.deleteMany({});
+        await AlignmentParentModel.deleteMany({});
+    });
+
+    const createParentWithChildren = async () => {
+        const [childA, childB, childC] = await AlignmentChildModel.create([{ name: 'A' }, { name: 'B' }, { name: 'C' }]);
+        const parent = await AlignmentParentModel.create({
+            title: 'P',
+            members: [
+                { child: childA._id, role: 'first' },
+                { child: childB._id, role: 'second' },
+                { child: childC._id, role: 'third' },
+            ],
+            kids: [childA._id, childB._id, childC._id],
+            favorite: childB._id,
+        });
+        return { childA, childB, childC, parent };
+    };
+
+    describe('path through a sub-document array (members.child)', () => {
+        it('keeps positions aligned and sets null for a dangling ref, like native populate', async () => {
+            const { childB, parent } = await createParentWithChildren();
+            await AlignmentChildModel.deleteOne({ _id: childB._id });
+
+            const result = (await AlignmentParentModel.findById(parent._id).cachePopulate({ path: 'members.child' }).exec()) as IAlignmentParent;
+
+            expect(result.members).toHaveLength(3);
+            expect((result.members[0].child as IAlignmentChild).name).toBe('A');
+            expect(result.members[1].child).toBeNull();
+            expect((result.members[2].child as IAlignmentChild).name).toBe('C');
+            expect(typeof (result.members[0].child as IAlignmentChild).ping).toBe('function');
+            expect((result.members[2].child as IAlignmentChild).ping()).toBe('pong');
+
+            const native = (await AlignmentParentModel.findById(parent._id).populate('members.child').exec()) as IAlignmentParent;
+            expect(result.members.map(member => (member.child ? (member.child as IAlignmentChild).name : null))).toEqual(native.members.map(member => (member.child ? (member.child as IAlignmentChild).name : null)));
+        });
+
+        it('populates every member when all refs resolve', async () => {
+            const { parent } = await createParentWithChildren();
+
+            const result = (await AlignmentParentModel.findById(parent._id).cachePopulate({ path: 'members.child' }).exec()) as IAlignmentParent;
+
+            expect(result.members.map(member => (member.child as IAlignmentChild).name)).toEqual(['A', 'B', 'C']);
+            for (const member of result.members) {
+                expect(member.child).toBeInstanceOf(mongoose.Document);
+            }
+        });
+
+        it('keeps the null placeholder for lean queries', async () => {
+            const { childB, parent } = await createParentWithChildren();
+            await AlignmentChildModel.deleteOne({ _id: childB._id });
+
+            const result = await AlignmentParentModel.findById(parent._id).lean().cachePopulate({ path: 'members.child' }).exec();
+
+            expect(result!.members).toHaveLength(3);
+            expect((result!.members[0].child as IAlignmentChild).name).toBe('A');
+            expect(result!.members[1].child).toBeNull();
+            expect((result!.members[2].child as IAlignmentChild).name).toBe('C');
+            expect(result!.members[0].child).not.toBeInstanceOf(mongoose.Document);
+        });
+    });
+
+    describe('direct ref array (kids)', () => {
+        it('drops a dangling ref without null placeholders, like native populate', async () => {
+            const { childB, parent } = await createParentWithChildren();
+            await AlignmentChildModel.deleteOne({ _id: childB._id });
+
+            const result = (await AlignmentParentModel.findById(parent._id).cachePopulate({ path: 'kids' }).exec()) as IAlignmentParent;
+
+            expect(result.kids).toHaveLength(2);
+            expect(result.kids.map(kid => (kid as IAlignmentChild).name)).toEqual(['A', 'C']);
+
+            const native = (await AlignmentParentModel.findById(parent._id).populate('kids').exec()) as IAlignmentParent;
+            expect(result.kids.map(kid => (kid as IAlignmentChild).name)).toEqual(native.kids.map(kid => (kid as IAlignmentChild).name));
+        });
+    });
+
+    describe('single ref (favorite)', () => {
+        it('sets null for a dangling ref, like native populate', async () => {
+            const { childB, parent } = await createParentWithChildren();
+            await AlignmentChildModel.deleteOne({ _id: childB._id });
+
+            const result = (await AlignmentParentModel.findById(parent._id).cachePopulate({ path: 'favorite' }).exec()) as IAlignmentParent;
+
+            expect(result.favorite).toBeNull();
+        });
+    });
+});

--- a/test/features/cachePopulate.test.ts
+++ b/test/features/cachePopulate.test.ts
@@ -372,7 +372,7 @@ describe('cachePopulate', () => {
         const secondResult = await UserModel.findOne({ _id: child._id }).cachePopulate({ path: 'parent' }).exec();
 
         expect(secondResult).toBeDefined();
-        expect(secondResult!.parent).toBeUndefined(); // Parent should not be found in cache
+        expect(secondResult!.parent).toBeNull(); // Deleted ref resolves to null, like native populate
     });
 
     // Cache Invalidation on Populated Document Update

--- a/test/utils/populationUtils.test.ts
+++ b/test/utils/populationUtils.test.ts
@@ -423,7 +423,7 @@ describe('populationUtils', () => {
 
             expect(result).toHaveLength(1);
             const populatedChild = result[0] as IUser;
-            expect(populatedChild.parent).toBeUndefined();
+            expect(populatedChild.parent).toBeNull();
         });
     });
 
@@ -546,7 +546,7 @@ describe('populationUtils', () => {
             const docsFromCache = new Map();
             docsFromCache.set(getDocumentCacheKey('User', parent1._id.toString()), parent1.toObject());
             docsFromCache.set(getDocumentCacheKey('User', parent2._id.toString()), parent2.toObject());
-            await stitchAndRelateDocuments([childDoc], 'parents', UserModel, undefined, docsFromCache, false);
+            await stitchAndRelateDocuments([childDoc], 'parents', UserModel, undefined, docsFromCache, false, undefined, true);
             expect(childDoc.parents).toHaveLength(2);
             expect((childDoc.parents[0] as any).name).toBe('Parent1');
             expect((childDoc.parents[1] as any).name).toBe('Parent2');
@@ -590,7 +590,7 @@ describe('populationUtils', () => {
             const childDoc = await UserModel.findById(child._id);
             const docsFromCache = new Map();
             docsFromCache.set(getDocumentCacheKey('User', parent._id.toString()), parent.toObject());
-            await stitchAndRelateDocuments([childDoc], 'parents', UserModel, undefined, docsFromCache, false);
+            await stitchAndRelateDocuments([childDoc], 'parents', UserModel, undefined, docsFromCache, false, undefined, true);
             // Should only have the valid parent, null filtered out
             expect((childDoc.parents as any[]).length).toBe(1);
             expect((childDoc.parents[0] as any).name).toBe('Parent');
@@ -632,7 +632,7 @@ describe('populationUtils', () => {
             const childDoc = await UserModel.findById(child._id);
             const docsFromCache = new Map(); // No parent in cache
             await stitchAndRelateDocuments([childDoc], 'parent', UserModel, undefined, docsFromCache, false);
-            expect(childDoc.parent).toBeUndefined();
+            expect(childDoc.parent).toBeNull();
         });
     });
 });


### PR DESCRIPTION
When a cachePopulate path traverses an array of sub-documents (e.g. `members.child`) and a ref cannot be resolved (referenced document deleted), the stitched array was shortened by `.filter(Boolean)` before `mpath.set` wrote it back positionally. Later elements received the wrong populated document and a trailing element was left as a raw `ObjectId`.

Now the behavior matches native populate:
- paths through sub-document arrays keep a null placeholder at the original position, so every element stays aligned and hydrated
- direct ref arrays keep dropping unresolved refs (unchanged)
- a single unresolvable ref resolves to null instead of undefined

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed populated references in nested document arrays so unresolved references retain their positions as `null`.
  * Direct reference arrays continue to omit unresolved entries.
  * Missing single-reference values now consistently resolve to `null`.
  * Improved alignment and consistency for both standard and lean queries.

* **Tests**
  * Added regression coverage for dangling references and array alignment.
  * Updated expectations for missing populated values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->